### PR TITLE
Allow null as a type into ai module

### DIFF
--- a/ballerina/tool_types.bal
+++ b/ballerina/tool_types.bal
@@ -24,7 +24,8 @@ public enum InputType {
     BOOLEAN = "boolean",
     NUMBER = "number",
     OBJECT = "object",
-    ARRAY = "array"
+    ARRAY = "array",
+    NULL = "null"
 }
 
 # Primitive types supported by the Tool schemas.


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/ballerina-library/issues/7982

