### PR TITLE
Add Vector Store Interface

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "file"},
 	{org = "ballerina", name = "http"},
@@ -30,7 +30,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "http"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerina"
 name = "ai"
-version = "1.0.0"
+version = "1.0.1"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["AI/Agent", "Cost/Freemium", "Agent", "AI"]
@@ -14,5 +14,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.0.0"
-path = "../native/build/libs/ai-native-1.0.0.jar"
+version = "1.0.1"
+path = "../native/build/libs/ai-native-1.0.1-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-compiler-plugin"
 class = "io.ballerina.stdlib.ai.plugin.AiCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.0.0.jar"
+path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.0.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/rag_types.bal
+++ b/ballerina/rag_types.bal
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Represents a dense vector with floating-point values.
+public type Vector float[];
+
+# Represents a sparse vector storing only non-zero values with their corresponding indices.
+#
+# + indices - Array of indices where non-zero values are located 
+# + values - Array of non-zero floating-point values corresponding to the indices
+public type SparseVector record {|
+    int[] indices;
+    Vector values;
+|};
+
+# Represents a hybrid embedding containing both dense and sparse vector representations.
+#
+# + dense - Dense vector representation of the embedding
+# + sparse - Sparse vector representation of the embedding
+public type HybridVector record {|
+    Vector dense;
+    SparseVector sparse;
+|};
+
+# Represents possible vector types.
+public type Embedding Vector|SparseVector|HybridVector;
+
+# Represents the set of supported operators used for metadata filtering during vector search operations.
+public enum MetadataFilterOperator {
+    EQUAL = "==",
+    NOT_EQUAL = "!=",
+    GREATER_THAN = ">",
+    LESS_THAN = "<",
+    GREATER_THAN_OR_EQUAL = ">=",
+    LESS_THAN_OR_EQUAL = "<=",
+    IN = "in",
+    NOT_IN = "nin"
+}
+
+# Represents logical conditions for combining multiple metadata filtering during vector search operations.
+public enum MetadataFilterCondition {
+    AND = "and",
+    OR = "or"
+}
+
+# Represents a metadata filter for vector search operations.
+# Defines conditions to filter vectors based on their associated metadata values.
+#
+# + key - The name of the metadata field to filter
+# + operator - The comparison operator to use. Defaults to `EQUAL`
+# + value - - The value to compare the metadata field against
+public type MetadataFilter record {|
+    string key;
+    MetadataFilterOperator operator = EQUAL;
+    json value;
+|};
+
+# Represents a container for combining multiple metadata filters using logical operators.
+# Enables complex filtering by applying multiple conditions with AND/OR logic during vector search.
+#
+# + filters - An array of `MetadataFilter` or nested `MetadataFilters` to apply.
+# + condition - The logical operator (`AND` or `OR`) used to combine the filters. Defaults to `AND`.
+public type MetadataFilters record {|
+    (MetadataFilters|MetadataFilter)[] filters;
+    MetadataFilterCondition condition = AND;
+|};
+
+# Defines a query to the vector store with an embedding vector and optional metadata filters.
+# Supports precise search operations by combining vector similarity with metadata conditions.
+#
+# + embedding - The vector to use for similarity search.
+# + filters - Optional metadata filters to refine the search results.
+public type VectorStoreQuery record {|
+    Embedding embedding;
+    MetadataFilters filters?;
+|};
+
+# Represents a document with content and optional metadata.
+#
+# + content - The main text content of the document
+# + metadata - Optional key-value pairs that provide additional information about the document
+public type Document record {|
+    string content;
+    map<anydata> metadata?;
+|};
+
+# Represents a vector entry combining an embedding with its source document.
+#
+# + id - Optional unique identifier for the vector entry
+# + embedding - The vector representation of the document content
+# + document - The original document associated with the embedding
+public type VectorEntry record {|
+    string id?;
+    Embedding embedding;
+    Document document;
+|};
+
+# Represents a vector match result with similarity score.
+#
+# + similarityScore - Similarity score indicating how closely the vector matches the query 
+public type VectorMatch record {|
+    *VectorEntry;
+    float similarityScore;
+|};
+
+# Represents query modes to be used with vector store.
+# Defines different search strategies for retrieving relevant documents
+# based on the type of embeddings and search algorithms to be used.
+public enum VectorStoreQueryMode {
+    DENSE,
+    SPARSE,
+    HYBRID
+}

--- a/ballerina/rag_utils.bal
+++ b/ballerina/rag_utils.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Splits content into documents based on line breaks.
+# Each non-empty line becomes a separate document with the line content.
+# Empty lines and lines containing only whitespace are filtered out.
+#
+# + content - The input text content to be split by lines
+# + return - Array of documents, one per non-empty line
+public isolated function splitDocumentByLine(string content) returns Document[] {
+    string[] lines = re `\n`.split(content);
+    return from string line in lines
+        where line.trim() != ""
+        select {content: line.trim()};
+}

--- a/ballerina/vector-store.bal
+++ b/ballerina/vector-store.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Represents a vector store that provides persistence, management, and search capabilities for vector embeddings.
+public type VectorStore isolated object {
+
+    # Adds vector entries to the store.
+    #
+    # + entries - The array of vector entries to add
+    # + return - An `Error` if the operation fails; otherwise, `nil`
+    public isolated function add(VectorEntry[] entries) returns Error?;
+
+    # Searches for vectors in the store that are most similar to a given query.
+    #
+    # + query - The vector store query that specifies the search criteria
+    # + return - An array of matching vectors with their similarity scores,
+    # or an `Error` if the operation fails
+    public isolated function query(VectorStoreQuery query) returns VectorMatch[]|Error;
+
+    # Deletes a vector entry from the store by its unique ID.
+    #
+    # + id - The unique identifier of the vector entry to delete
+    # + return - An `Error` if the operation fails; otherwise, `nil`
+    public isolated function delete(string id) returns Error?;
+};

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.0.0"
+version = "1.0.1"
 
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
## Description
This commit introduces the `VectorStore` interface that defines a standard contract for managing vector embeddings, including operations for adding, querying, and deleting entries. The interface supports dense, sparse, and hybrid vectors, along with powerful metadata-based filtering.

Key features:
- `VectorStore` isolated object with `add`, `query`, and `delete` methods.
- Unified `Embedding` type supporting dense, sparse, and hybrid representations.
- Metadata filtering via `MetadataFilter`, `MetadataFilters`, and logical operators.
- `VectorStoreQuery` combining embeddings and filter conditions.
- Supporting types for documents, vector entries, and match results.
- Line-based document splitter utility (`splitDocumentByLine`).

Related issue: [https://github.com/ballerina-platform/ballerina-library/issues/7870](https://github.com/ballerina-platform/ballerina-library/issues/7870)

## Examples

## Checklist
- [x] Linked to an issue
