### PR TITLE
Fix knowledge base retrieve span missing input/output tags

### DIFF
--- a/ changelog.md
+++ b/ changelog.md
@@ -4,6 +4,12 @@ This file documents all significant changes made to the Ballerina AI package acr
 
 ## [Unreleased]
 
+### Fixed
+[Fix Knowledge Base Retrieve Span Missing Input/Output tags](https://github.com/wso2/product-integrator/issues/635)
+
+## [1.11.0] - 2026-03-27
+
+### Added
 - [Add Agent Identity](https://github.com/ballerina-platform/module-ballerina-ai/pull/126)
 
 ## [1.10.0] - 2026-03-14

--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerina"
 name = "ai"
-version = "1.11.0"
+version = "1.11.1"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["AI/Agent", "Cost/Freemium", "Agent", "Vendor/N/A", "Area/AI", "Type/Connector"]
@@ -19,14 +19,14 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true
 
 [[platform.java21.dependency]]

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-compiler-plugin"
 class = "io.ballerina.stdlib.ai.plugin.AiCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.11.0-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.11.1-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.2.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/modules/observe/knowledge-base-spans.bal
+++ b/ballerina/modules/observe/knowledge-base-spans.bal
@@ -112,7 +112,14 @@ public isolated distinct class KnowledgeBaseRetrieveSpan {
     #
     # + query - The input query to retrieve data
     public isolated function addInputQuery(json query) {
-        self.addTag(KNOWLEDGE_BASE_INGEST_INPUT_CHUNKS, query);
+        self.addTag(KNOWLEDGE_BASE_RETRIEVE_INPUT_QUERY, query);
+    }
+
+    # Records the output retrieved from the knowledge base.
+    #
+    # + output - The retrieved result
+    public isolated function addOutput(json output) {
+        self.addTag(KNOWLEDGE_BASE_RETRIEVE_OUTPUT, output);
     }
 
     # Records the maximum limit for the retrieve operation.

--- a/ballerina/modules/observe/observe.bal
+++ b/ballerina/modules/observe/observe.bal
@@ -57,6 +57,7 @@ enum GenAiTagNames {
     KNOWLEDGE_BASE_ID = "gen_ai.knowledge_base.id",
     KNOWLEDGE_BASE_INGEST_INPUT_CHUNKS = "gen_ai.knowledge_base.ingest.input.chunks",
     KNOWLEDGE_BASE_RETRIEVE_INPUT_QUERY = "gen_ai.knowledge_base.retrieve.input.query",
+    KNOWLEDGE_BASE_RETRIEVE_OUTPUT = "gen_ai.knowledge_base.retrieve.output",
     KNOWLEDGE_BASE_RETRIEVE_INPUT_LIMIT = "gen_ai.knowledge_base.retrieve.input.limit",
     KNOWLEDGE_BASE_RETRIEVE_INPUT_FILTER = "gen_ai.knowledge_base.retrieve.input.filter",
 

--- a/ballerina/rag.bal
+++ b/ballerina/rag.bal
@@ -177,10 +177,10 @@ public distinct isolated class VectorKnowledgeBase {
         observe:KnowledgeBaseRetrieveSpan span = observe:createKnowledgeBaseRetrieveSpan(VECTOR_KNOWLDEGE_BASE);
         span.addId(self.id);
         if filters is MetadataFilters {
-            span.addInputQuery(query);
+            span.addFilter(filters.toJson());
         }
         span.addLimit(topK);
-        span.addFilter(filters.toJson());
+        span.addInputQuery(query);
 
         QueryMatch[]|Error queryMatch = self.retriever.retrieve(query, topK, filters);
 
@@ -188,6 +188,7 @@ public distinct isolated class VectorKnowledgeBase {
             span.close(queryMatch);
             return queryMatch;
         }
+        span.addOutput(queryMatch.toJson());
         span.close();
         return queryMatch;
     }

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/03_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/03_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/04_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/04_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/05_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/05_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/06_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/06_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/07_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/07_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/08_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/08_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/09_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/09_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/10_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/10_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/11_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/11_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/12_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/12_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/07_tool_with_context_in_invalid_position/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/07_tool_with_context_in_invalid_position/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/08_local_tool_with_scope_annotation/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/08_local_tool_with_scope_annotation/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.0"
+version = "1.11.1"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.0"
-path = "../../../../../../../native/build/libs/ai-native-1.11.0-SNAPSHOT-tests.jar"
+version = "1.11.1"
+path = "../../../../../../../native/build/libs/ai-native-1.11.1-SNAPSHOT-tests.jar"
 testOnly = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.11.0-SNAPSHOT
+version=1.11.1-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 ballerinaGradlePluginVersion=3.0.0


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-integrator/issues/635

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
<img width="1272" height="946" alt="image" src="https://github.com/user-attachments/assets/70e9c2b0-f6c0-40a8-89d9-a9764ade478c" />

- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes the missing input/output attributes on observability spans generated during knowledge base retrieval operations, addressing issue #635. The fix ensures that distributed tracing systems can properly capture and display the query input and retrieval results for knowledge base operations.

## Key Changes

**Observability Enhancements:**
- Added a new `KNOWLEDGE_BASE_RETRIEVE_OUTPUT` tag constant to the observability framework with value `"gen_ai.knowledge_base.retrieve.output"`
- Fixed the `KnowledgeBaseRetrieveSpan` class to correctly tag input queries with `KNOWLEDGE_BASE_RETRIEVE_INPUT_QUERY` instead of using the incorrect `KNOWLEDGE_BASE_INGEST_INPUT_CHUNKS` tag
- Added a new `addOutput()` method to `KnowledgeBaseRetrieveSpan` to record the retrieved results from knowledge base operations

**Runtime Behavior:**
- Updated `VectorKnowledgeBase.retrieve()` to explicitly record both input query and output results on the observability span, ensuring these attributes are available in distributed tracing logs

**Version Updates:**
- Incremented package version from 1.11.0 to 1.11.1 across the main module and test fixtures
- Updated all corresponding native library dependencies and JAR paths to reference the 1.11.1 artifacts
- Updated changelog to document the fix

## Testing & Compatibility
- Changelog updated per contribution guidelines
- All test fixture configurations updated to reference the new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->