### PR TITLE
Fix maxIter inference with toolkits and enforce minimum of 10

### DIFF
--- a/ changelog.md
+++ b/ changelog.md
@@ -4,10 +4,13 @@ This file documents all significant changes made to the Ballerina AI package acr
 
 ## [Unreleased]
 
+### Fixed
+- [Fix `maxIter` Inference with Toolkits and Efnorce Minimum of 10](https://github.com/wso2/product-integrator/issues/1112)
+
 ## [1.11.1] - 2026-04-16
 
 ### Fixed
-[Fix Knowledge Base Retrieve Span Missing Input/Output tags](https://github.com/wso2/product-integrator/issues/635)
+- [Fix Knowledge Base Retrieve Span Missing Input/Output tags](https://github.com/wso2/product-integrator/issues/635)
 
 ## [1.11.0] - 2026-03-27
 

--- a/ changelog.md
+++ b/ changelog.md
@@ -5,7 +5,7 @@ This file documents all significant changes made to the Ballerina AI package acr
 ## [Unreleased]
 
 ### Fixed
-- [Fix `maxIter` Inference with Toolkits and Efnorce Minimum of 10](https://github.com/wso2/product-integrator/issues/1112)
+- [Fix `maxIter` Inference with Toolkits and Enforce Minimum of 10](https://github.com/wso2/product-integrator/issues/1112)
 
 ## [1.11.1] - 2026-04-16
 

--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina-tests/tests/agent-test.bal
+++ b/ballerina-tests/tests/agent-test.bal
@@ -74,3 +74,19 @@ function testAgentWithDynamicToolLoadingConfig() returns error? {
         test:assertTrue(toolLoadedDynamicaly);
     }
 }
+
+@test:Config
+function testAgentWithMaxIterConfiguration() returns error? {
+    string imageUrl = "https://ballerina.io/images/ballerina.png";
+    ai:Context ctx = new;
+    ctx.set("imageUrl", imageUrl);
+    ctx.set("isImageSearchToolExecuted", false);
+
+    string|error result = agentWithMaxIter1.run("Search for a 'ballerina' image", context = ctx);
+    test:assertTrue(result is ai:MaxIterationExceededError);
+
+    string response = check agentWithInferToolCount.run("Search for a 'ballerina' image", context = ctx);
+    test:assertEquals(response, string `Answer is: ${imageUrl}`);
+    boolean isImageSearchToolExecuted = check ctx.getWithType("isImageSearchToolExecuted");
+    test:assertTrue(isImageSearchToolExecuted);
+}

--- a/ballerina-tests/tests/agent-with-mock-llm.bal
+++ b/ballerina-tests/tests/agent-with-mock-llm.bal
@@ -170,6 +170,18 @@ final ai:Agent dynamicToolLoadingAgent = check new (model = model,
     toolLoadingStrategy = ai:LLM_FILTER
 );
 
+final ai:Agent agentWithMaxIter1 = check new (model = model, maxIter = 1,
+    systemPrompt = {role: "Math tutor", instructions: "Help the students with their questions."},
+    tools = [new SearchToolKit()],
+    verbose = true
+);
+
+final ai:Agent agentWithInferToolCount = check new (model = model,
+    systemPrompt = {role: "Math tutor", instructions: "Help the students with their questions."},
+    tools = [new SearchToolKit()],
+    verbose = true
+);
+
 isolated class SearchToolKit {
     *ai:BaseToolKit;
 

--- a/ballerina/agent.bal
+++ b/ballerina/agent.bal
@@ -76,7 +76,8 @@ public type AgentConfiguration record {|
     (BaseToolKit|ToolConfig|FunctionTool)[] tools = [];
 
     # The maximum number of iterations the agent performs to complete the task.
-    # By default, it is set to the number of tools + 1.
+    # Defaults to `max(number of tools, 10)` — i.e., at least 10, or more if the
+    # agent has more tools available.
     @display {label: "Maximum Iterations"}
     INFER_TOOL_COUNT|int maxIter = INFER_TOOL_COUNT;
 
@@ -119,7 +120,6 @@ public isolated distinct class Agent {
         span.addSystemInstructions(getFomatedSystemPrompt(config.systemPrompt));
 
         INFER_TOOL_COUNT|int maxIter = config.maxIter;
-        self.maxIter = maxIter is INFER_TOOL_COUNT ? config.tools.length() + 1 : maxIter;
         self.verbose = config.verbose;
         self.systemPrompt = config.systemPrompt.cloneReadOnly();
         Memory? memory = config.hasKey("memory") ? config?.memory : check new ShortTermMemory();
@@ -134,8 +134,10 @@ public isolated distinct class Agent {
         }
         do {
             self.functionCallAgent = check new FunctionCallAgent(config.model, config.tools, self.tokenManager,
-                agentCredential, memory, config.toolLoadingStrategy);
+                agentCredential, memory, config.toolLoadingStrategy
+            );
             self.toolSchemas = self.functionCallAgent.toolStore.getToolSchema().cloneReadOnly();
+            self.maxIter = maxIter is INFER_TOOL_COUNT ? int:max(self.toolSchemas.length(), 10) : maxIter;
             span.addTools(self.functionCallAgent.toolStore.getToolsInfo());
             if agentIdentitySpan is observe:CreateAgentIdentitySpan {
                 agentIdentitySpan.close();
@@ -173,10 +175,10 @@ public isolated distinct class Agent {
         time:Utc startTime = time:utcNow();
         string executionId = uuid:createRandomUuid();
         log:printDebug("Agent execution started",
-            executionId = executionId,
-            agentId = self.agentId,
-            query = query,
-            sessionId = sessionId
+                executionId = executionId,
+                agentId = self.agentId,
+                query = query,
+                sessionId = sessionId
         );
 
         observe:InvokeAgentSpan span = observe:createInvokeAgentSpan(self.systemPrompt.role);
@@ -194,10 +196,10 @@ public isolated distinct class Agent {
         do {
             string answer = check getAnswer(executionTrace, self.maxIter);
             log:printDebug("Agent execution completed successfully",
-                executionId = executionId,
-                agentId = self.agentId,
-                steps = executionTrace.steps.toString(),
-                answer = answer
+                    executionId = executionId,
+                    agentId = self.agentId,
+                    steps = executionTrace.steps.toString(),
+                    answer = answer
             );
             span.addOutput(observe:TEXT, answer);
             span.close();
@@ -216,10 +218,10 @@ public isolated distinct class Agent {
                 : answer;
         } on fail Error err {
             log:printDebug("Agent execution failed",
-                err,
-                executionId = executionId,
-                agentId = self.agentId,
-                steps = executionTrace.steps.toString()
+                    err,
+                    executionId = executionId,
+                    agentId = self.agentId,
+                    steps = executionTrace.steps.toString()
             );
             span.close(err);
 

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/03_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/03_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/04_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/04_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/05_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/05_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/06_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/06_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/07_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/07_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/08_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/08_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/09_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/09_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/10_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/10_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/11_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/11_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/12_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/12_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/07_tool_with_context_in_invalid_position/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/07_tool_with_context_in_invalid_position/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/08_local_tool_with_scope_annotation/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/08_local_tool_with_scope_annotation/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.1"
+version = "1.11.2"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.1"
-path = "../../../../../../../native/build/libs/ai-native-1.11.1-tests.jar"
+version = "1.11.2"
+path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
 testOnly = true


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-integrator/issues/1112

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request addresses an issue where chat agents would fail with iteration limit errors when configured with a small number of tools or toolkits. The fix improves the default behavior by increasing the iteration limit and enforcing a minimum threshold.

## Key Changes

**Core Fix — maxIter Inference Logic (ballerina/agent.bal)**
- Updated the iteration limit calculation to base the count on loaded tool schemas rather than the initial tools list
- Changed from `config.tools.length() + 1` to `max(self.toolSchemas.length(), 10)`, enforcing a minimum of 10 iterations
- This calculation now occurs after the FunctionCallAgent is constructed and tool schemas are cloned, ensuring the iteration count reflects the actual available tools

**Testing**
- Added a new test case (`testAgentWithMaxIterConfiguration`) that validates agent behavior with explicit max-iteration constraints
- Extended the test agent configurations to include agents with `maxIter = 1` and default configurations for comparison testing

**Maintenance Updates**
- Updated changelog with an entry documenting the maxIter inference fix
- Bumped package version from 1.11.1 to 1.11.2 across all Ballerina manifest files (ballerina-tests and compiler-plugin-tests)
- Updated Java21 platform dependency paths to reference the new 1.11.2-SNAPSHOT artifacts

## Impact

This change improves the first-time user experience by reducing timeout failures for agents working with a limited number of tools, while maintaining the ability for users to customize the iteration limit when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->