### PR TITLE
Update maxIter calculation to use DEFAULT_MINIMUM_MAX_ITERATIONS constant

### DIFF
--- a/ballerina/agent.bal
+++ b/ballerina/agent.bal
@@ -23,6 +23,7 @@ import ballerina/time;
 import ballerina/uuid;
 
 const INFER_TOOL_COUNT = "INFER_TOOL_COUNT";
+const DEFAULT_MINIMUM_MAX_ITERATIONS = 10;
 
 # Represents the system prompt given to the agent.
 @display {label: "System Prompt"}
@@ -137,7 +138,8 @@ public isolated distinct class Agent {
                 agentCredential, memory, config.toolLoadingStrategy
             );
             self.toolSchemas = self.functionCallAgent.toolStore.getToolSchema().cloneReadOnly();
-            self.maxIter = maxIter is INFER_TOOL_COUNT ? int:max(self.toolSchemas.length(), 10) : maxIter;
+            self.maxIter = maxIter is INFER_TOOL_COUNT ?
+                int:max(self.toolSchemas.length(), DEFAULT_MINIMUM_MAX_ITERATIONS) : maxIter;
             span.addTools(self.functionCallAgent.toolStore.getToolsInfo());
             if agentIdentitySpan is observe:CreateAgentIdentitySpan {
                 agentIdentitySpan.close();


### PR DESCRIPTION
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request refactors the agent iteration limit calculation by extracting a hardcoded minimum value into a named constant for improved code maintainability and clarity.

**Changes Made:**

- Introduced a new module-level constant `DEFAULT_MINIMUM_MAX_ITERATIONS` with a value of `10`
- Updated the `maxIter` calculation logic in the `Agent.init()` function to reference this constant instead of using an inline literal

**Impact:**

When the agent configuration sets `maxIter` to `INFER_TOOL_COUNT`, the maximum iteration limit is calculated as the maximum of the number of available tool schemas and the minimum threshold. Previously, this minimum threshold was defined as a magic number (`10`) embedded in the calculation logic. It is now sourced from the named constant, making the code more maintainable and the intent clearer.

No public APIs or exported signatures are affected by this change. All existing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->