### PR TITLE
Bump openNlpToolsVersion to 2.5.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ downloadPluginVersion=5.4.0
 releasePluginVersion=2.6.0
 swaggerVersion=2.2.9
 jacocoVersion=0.8.10
-openNlpToolsVersion=2.5.4
+openNlpToolsVersion=2.5.9
 langchain4jVersion=1.1.0
 
 # Ballerina Library Dependencies


### PR DESCRIPTION
## Summary

Bumps `openNlpToolsVersion` from `2.5.4` to `2.5.9` to address three vulnerabilities detected by Trivy in the `opennlp-tools` jar bundled in the distribution.

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-40682 | CRITICAL | XML External Entity (XXE) via Unsanitized Dictionary Parsing |
| CVE-2026-42027 | CRITICAL | Arbitrary Class Loading via Model Manifest |
| CVE-2026-42440 | HIGH | OOM Denial of Service via Unbounded Array Allocation |

Fixed in Apache OpenNLP `2.5.9` and `3.0.0-M3`.

## Test plan
- [ ] CI passes
- [ ] Trivy scan no longer reports `opennlp-tools-2.5.4.jar` vulnerabilities

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the `openNlpToolsVersion` dependency in `gradle.properties` from version 2.5.4 to 2.5.9. This upgrade resolves reported security vulnerabilities that were identified in the bundled Apache OpenNLP library, improving the overall stability and security posture of the project. The change is minimal and low-risk, affecting only the version specification in the build configuration.

## Changes

- **gradle.properties**: Updated `openNlpToolsVersion` from `2.5.4` to `2.5.9`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->