### PR TITLE
feat: add maxTokens configuration to generator settings and request p…

### DIFF
--- a/ballerina/default-model-provider-utils.bal
+++ b/ballerina/default-model-provider-utils.bal
@@ -227,7 +227,8 @@ isolated function generateLlmResponse(intelligence:Client llmClient, decimal tem
             messages: [{role: USER, "content": content}],
             tools,
             toolChoice: getGetResultsToolChoice(),
-            temperature
+            temperature,
+            maxTokens: generatorConfig?.maxTokens ?: 4096
         };
         span.addInputMessages(request.messages.toJson());
 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -124,6 +124,12 @@ public type GeneratorConfig record {|
     # Configuration for retrying on response parsing failures
     @display {label: "Retry Configuration"}
     RetryConfig retryConfig?;
+
+    # Maximum number of tokens to generate in the response.
+    # Defaults to 4096 to ensure maximum compatibility across different LLM providers.
+    # The maximum allowed value depends on the model (e.g., gpt-4o-mini supports up to 16384).
+    @display {label: "Max Output Tokens"}
+    int maxTokens?;
 |};
 
 # Represents retry configuration on response parsing failures.


### PR DESCRIPTION
## Purpose
Fixes the issue where LLM responses get truncated or cut off due to an unconfigured `max_tokens` parameter in the chat completion request payload.
When `max_tokens` is omitted, the OpenAI API defaults the output limit to `(4096 - prompt_tokens)`. For large prompts with extensive context, this drastically reduces the output budget, resulting in truncated or incomplete JSON responses.
This PR introduces an optional `maxTokens` field to `GeneratorConfig`, which is explicitly sent in the chat completion request. It defaults to `4096` to ensure maximum compatibility across different LLM providers, while allowing callers to increase the limit up to the model's maximum (e.g., `16384` for `gpt-4o-mini`).
## Examples
### 1. Default Behavior (Backward Compatible)
No changes required for existing users. The provider now explicitly sends `max_tokens: 4096`, ensuring the output budget is never squeezed by prompt size.
```ballerina
ai:Wso2ModelProvider provider = check new ("https://your-ai-service-url", "your-token");
```
### 2. Customizing Output up to 16,384 Tokens
For large output tasks (e.g., generating heavy schemas or code) using modern models, you can configure the maximum output token size using named arguments:
```ballerina
ai:GeneratorConfig config = {
    maxTokens: 16384
};
ai:Wso2ModelProvider provider = check new (
    "https://your-ai-service-url",
    "your-token",
    generatorConfig = config
);
```
## Checklist
- **Linked to an issue**
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This pull request adds configurable maximum token output limits to the LLM generator settings. It introduces an optional `maxTokens` field to `GeneratorConfig` that controls the maximum number of tokens generated in chat completion responses.

## Changes
- **`types.bal`**: Added optional `maxTokens?: int` field to the `GeneratorConfig` record with a display label "Max Output Tokens"
- **`default-model-provider-utils.bal`**: Updated the `generateLlmResponse` function to explicitly set `max_tokens` in the chat completion request payload, using the configured value or defaulting to 4096

## Rationale
The change addresses response truncation issues by explicitly setting the maximum tokens parameter in requests. Without this configuration, some LLM providers (notably OpenAI) calculate the effective max_tokens as 4096 minus the prompt token count, which can result in truncated responses for large prompts. This update allows callers to specify their required output limits (up to model maximums like 16384 for gpt-4o-mini) while maintaining backward compatibility through the 4096 default.

## Impact
- **Backward compatible**: Existing code continues to work without modification; the 4096 default is applied automatically
- **Flexibility**: Callers can now configure higher output limits via named arguments when needed
- **Reliability**: Prevents unexpected response truncation in scenarios with large prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->