### PR TITLE
Allow all tool calls from a single LLM response to be executed together

### DIFF
--- a/ballerina-tests/Ballerina.toml
+++ b/ballerina-tests/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -300,7 +300,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.12.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -316,7 +316,7 @@ version = "1.2.0"
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.10.0"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -400,7 +400,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerina"
 name = "ai"
-version = "1.11.2"
+version = "1.12.0"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["AI/Agent", "Cost/Freemium", "Agent", "Vendor/N/A", "Area/AI", "Type/Connector"]
@@ -20,14 +20,14 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true
 
 [[platform.java21.dependency]]

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-compiler-plugin"
 class = "io.ballerina.stdlib.ai.plugin.AiCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.11.2-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ai-compiler-plugin-1.12.0-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.2.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/agent-utils.bal
+++ b/ballerina/agent-utils.bal
@@ -61,12 +61,6 @@ public type ExecutionError record {|
     string observation;
 |};
 
-# An chat response by the LLM
-type LlmChatResponse record {|
-    # A text response to the question
-    string content;
-|};
-
 # Tool selected by LLM to be performed by the agent
 public type LlmToolResponse record {|
     # Name of the tool to selected
@@ -92,6 +86,10 @@ class Executor {
     # Contains the current execution progress for the agent and the query
     public ExecutionProgress progress;
     private string? agentId = ();
+    # Tool calls from the LLM's latest response that are still pending execution.
+    # All of them are executed before the LLM is reasoned with again, so that a single
+    # LLM response containing multiple tool calls does not trigger multiple round-trips.
+    private FunctionCall[] pendingToolCalls = [];
 
     # Initialize the executor with the agent and the query.
     #
@@ -119,19 +117,19 @@ class Executor {
     # Reason the next step of the agent.
     #
     # + return - generated LLM response during the reasoning or an error if the reasoning fails
-    public isolated function reason() returns json|Error {
+    public isolated function reason() returns FunctionCall[]|string|Error {
         if self.isCompleted {
             log:printError("Task is already completed. No more reasoning is needed.",
-                agentId = self.agentId,
-                executionId = self.progress.executionId
+                    agentId = self.agentId,
+                    executionId = self.progress.executionId
             );
             return error TaskCompletedError("Task is already completed. No more reasoning is needed.");
         }
         log:printDebug("LLM reasoning started",
-            agentId = self.agentId,
-            executionId = self.progress.executionId,
-            sessionId = self.sessionId,
-            history = self.progress.executionSteps.toString()
+                agentId = self.agentId,
+                executionId = self.progress.executionId,
+                sessionId = self.sessionId,
+                history = self.progress.executionSteps.toString()
         );
         return check self.agent.selectNextTool(self.progress, self.sessionId);
     }
@@ -140,95 +138,93 @@ class Executor {
     #
     # + llmResponse - LLM response containing the tool to be executed and the raw LLM output
     # + return - Observations from the tool can be any|error|null
-    public isolated function act(json llmResponse) returns ExecutionResult|LlmChatResponse|ExecutionError{
-        LlmToolResponse|LlmChatResponse|LlmInvalidGenerationError parsedOutput = self.agent.parseLlmResponse(llmResponse);
-        if parsedOutput is LlmChatResponse {
+    public isolated function act(FunctionCall|string llmResponse) returns ExecutionResult|string|ExecutionError {
+        if llmResponse is string {
             log:printDebug("Parsed LLM response as chat response",
-                agentId = self.agentId,
-                executionId = self.progress.executionId,
-                sessionId = self.sessionId,
-                response = parsedOutput.content
+                    agentId = self.agentId,
+                    executionId = self.progress.executionId,
+                    sessionId = self.sessionId,
+                    response = llmResponse
             );
             self.isCompleted = true;
-            return parsedOutput;
+            return llmResponse;
         }
 
         anydata observation;
         ExecutionResult|ExecutionError executionResult;
-        if parsedOutput is LlmToolResponse {
-            string toolName = parsedOutput.name;
-            log:printDebug("Parsed LLM response as tool call",
+        string toolName = llmResponse.name;
+        log:printDebug("Parsed LLM response as tool call",
                 agentId = self.agentId,
                 executionId = self.progress.executionId,
                 sessionId = self.sessionId,
                 toolName = toolName,
-                arguments = parsedOutput.arguments
+                arguments = llmResponse.arguments
             );
-            observe:ExecuteToolSpan span = observe:createExecuteToolSpan(toolName);
-            string? toolCallId = parsedOutput.id;
-            if toolCallId is string {
-                span.addId(toolCallId);
-            }
-            ToolStore toolStore = self.agent.toolStore;
-            string? toolDescription = toolStore.getToolDescription(toolName);
-            if toolDescription is string {
-                span.addDescription(toolDescription);
-            }
-            boolean isMcpTool = toolStore.isMcpTool(toolName);
-            span.addType(isMcpTool ? observe:EXTENTION : observe:FUNCTION);
-            span.addArguments(parsedOutput.arguments);
-            ToolNotFoundError|ToolInvalidInputError|TokenAcquisitionError|TokenValidationError? 
-                    validateRes = validateTool(parsedOutput, self.agent.agentCredential, 
-                    self.agent.tokenManager, self.progress.context, toolStore.tools, isMcpTool);
-            if validateRes is Error {
-                log:printError("Tool validation failed",
+        observe:ExecuteToolSpan span = observe:createExecuteToolSpan(toolName);
+        string? toolCallId = llmResponse.id;
+        if toolCallId is string {
+            span.addId(toolCallId);
+        }
+        ToolStore toolStore = self.agent.toolStore;
+        string? toolDescription = toolStore.getToolDescription(toolName);
+        if toolDescription is string {
+            span.addDescription(toolDescription);
+        }
+        boolean isMcpTool = toolStore.isMcpTool(toolName);
+        span.addType(isMcpTool ? observe:EXTENTION : observe:FUNCTION);
+        span.addArguments(llmResponse.arguments);
+        ToolNotFoundError|ToolInvalidInputError|TokenAcquisitionError|TokenValidationError?
+                    validateRes = validateTool(llmResponse, self.agent.agentCredential,
+                self.agent.tokenManager, self.progress.context, toolStore.tools, isMcpTool);
+        if validateRes is Error {
+            log:printError("Tool validation failed",
                     agentId = self.agentId,
                     executionId = self.progress.executionId,
                     sessionId = self.sessionId,
                     toolName = toolName,
                     'error = validateRes
                 );
-                if validateRes is ToolNotFoundError|ToolInvalidInputError {
-                    observation = "Tool extraction failed due to tool validation"; 
-                    executionResult = {
-                        llmResponse,
-                        'error: validateRes,
-                        observation: observation.toString()
-                    };
-                    Error toolExecutionError = error Error(observation.toString(), details = {parsedOutput});
-                    span.close(toolExecutionError); 
-                } else {
-                    observation = "Tool execution failed while attempting to execute the selected tool: "
-                        + validateRes.message();
-                    executionResult = {
-                        llmResponse,
-                        'error: error UnauthorizedError (
-                            string `Tool execution failed: ${validateRes.message()}`, 
-                            details = { parsedOutput }, cause = validateRes.cause(), toolName= toolName),
-                        observation: observation.toString()
-                    };
-                    UnauthorizedError toolExecutionError = error UnauthorizedError(observation.toString(), 
-                        details = {parsedOutput});
-                    span.close(toolExecutionError); 
-                }
+            if validateRes is ToolNotFoundError|ToolInvalidInputError {
+                observation = "Tool extraction failed due to tool validation";
+                executionResult = {
+                    llmResponse,
+                    'error: validateRes,
+                    observation: observation.toString()
+                };
+                Error toolExecutionError = error Error(observation.toString(), details = {llmResponse});
+                span.close(toolExecutionError);
             } else {
-                ToolOutput|ToolExecutionError|LlmInvalidGenerationError output = toolStore.execute(parsedOutput,
+                observation = "Tool execution failed while attempting to execute the selected tool: "
+                        + validateRes.message();
+                executionResult = {
+                    llmResponse,
+                    'error: error UnauthorizedError(
+                            string `Tool execution failed: ${validateRes.message()}`,
+                            details = {llmResponse}, cause = validateRes.cause(), toolName = toolName),
+                    observation: observation.toString()
+                };
+                UnauthorizedError toolExecutionError = error UnauthorizedError(observation.toString(),
+                        details = {llmResponse});
+                span.close(toolExecutionError);
+            }
+        } else {
+            ToolOutput|ToolExecutionError|LlmInvalidGenerationError output = toolStore.execute(llmResponse,
                     self.progress.context);
-                if output is Error {
-                    if output is ToolNotFoundError {
-                        observation = "Tool is not found. Please check the tool name and retry.";
-                    } else if output is ToolInvalidInputError {
-                        observation = "Tool execution failed due to invalid inputs. Retry with correct inputs.";
-                    } else {
-                        observation = "Tool execution failed. Retry with correct inputs.";
-                    }
-                    observation = string `${observation.toString()} <detail>${output.toString()}</detail>`;
-                    executionResult = {
-                        llmResponse,
-                        'error: output,
-                        observation: observation.toString()
-                    };
-                    log:printError("Tool execution resulted in error",
+            if output is Error {
+                if output is ToolNotFoundError {
+                    observation = "Tool is not found. Please check the tool name and retry.";
+                } else if output is ToolInvalidInputError {
+                    observation = "Tool execution failed due to invalid inputs. Retry with correct inputs.";
+                } else {
+                    observation = "Tool execution failed. Retry with correct inputs.";
+                }
+                observation = string `${observation.toString()} <detail>${output.toString()}</detail>`;
+                executionResult = {
+                    llmResponse,
+                    'error: output,
+                    observation: observation.toString()
+                };
+                log:printError("Tool execution resulted in error",
                         agentId = self.agentId,
                         executionId = self.progress.executionId,
                         observation = observation.toString(),
@@ -236,40 +232,27 @@ class Executor {
                         toolName = toolName
                     );
 
-                    Error toolExecutionError = error Error(observation.toString(), details = {parsedOutput});
-                    span.close(toolExecutionError);
-                } else {
-                    anydata|error value = output.value;
-                    observation = value is error ? value.toString() : value;
-                    log:printDebug("Tool execution successful",
+                Error toolExecutionError = error Error(observation.toString(), details = {llmResponse});
+                span.close(toolExecutionError);
+            } else {
+                anydata|error value = output.value;
+                observation = value is error ? value.toString() : value;
+                log:printDebug("Tool execution successful",
                         agentId = self.agentId,
                         executionId = self.progress.executionId,
                         sessionId = self.sessionId,
                         toolName = toolName
                     );
-                    executionResult = {
-                        tool: parsedOutput,
-                        observation: value
-                    };
+                executionResult = {
+                    tool: llmResponse,
+                    observation: value
+                };
 
-                    span.addOutput(observation);
-                    span.close();
-                }
+                span.addOutput(observation);
+                span.close();
             }
-        } else {
-            log:printDebug("Failed to parse LLM response as valid tool or chat",
-                agentId = self.agentId,
-                executionId = self.progress.executionId,
-                sessionId = self.sessionId,
-                errorMessage = parsedOutput.message()
-            );
-            observation = "Tool extraction failed due to invalid JSON_BLOB. Retry with correct JSON_BLOB.";
-            executionResult = {
-                llmResponse,
-                'error: parsedOutput,
-                observation: observation.toString()
-            };
         }
+
         self.update({
             llmResponse,
             observation
@@ -288,7 +271,7 @@ class Executor {
     #
     # + return - a record with the execution step or an error if the agent failed
     public function iterator() returns object {
-        public function next() returns record {|ExecutionResult|LlmChatResponse|ExecutionError|Error value;|}?;
+        public function next() returns record {|ExecutionResult|string|ExecutionError|Error value;|}?;
     } {
         return self;
     }
@@ -296,15 +279,24 @@ class Executor {
     # Reason and execute the next step of the agent.
     #
     # + return - A record with ExecutionResult, chat response or an error 
-    public isolated function next() returns record {|ExecutionResult|LlmChatResponse|ExecutionError|Error value;|}? {
+    public isolated function next() returns record {|ExecutionResult|string|ExecutionError|Error value;|}? {
         if self.isCompleted {
             return ();
         }
-        json|Error llmResponse = self.reason();
-        if llmResponse is Error {
-            return {value: llmResponse};
+        if self.pendingToolCalls.length() == 0 {
+            FunctionCall[]|string|Error llmResponse = self.reason();
+            if llmResponse is Error {
+                return {value: llmResponse};
+            }
+            if llmResponse is string {
+                return {value: self.act(llmResponse)};
+            }
+            if llmResponse.length() > 0 {
+                self.pendingToolCalls = llmResponse;
+            }
         }
-        return {value: self.act(llmResponse)};
+        FunctionCall nextToolCall = self.pendingToolCalls.shift();
+        return {value: self.act(nextToolCall)};
     }
 }
 
@@ -325,12 +317,12 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
     time:Utc startTime = time:utcNow();
     Iteration[] iterations = [];
     log:printDebug("Agent execution loop started",
-        agentId = agentId,
-        executionId = executionId,
-        sessionId = sessionId,
-        maxIterations = maxIter,
-        tools = agent.toolStore.tools.toString(),
-        isStateless = agent.stateless
+            agentId = agentId,
+            executionId = executionId,
+            sessionId = sessionId,
+            maxIterations = maxIter,
+            tools = agent.toolStore.tools.toString(),
+            isStateless = agent.stateless
     );
 
     (ExecutionResult|ExecutionError|Error)[] steps = [];
@@ -365,7 +357,7 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
     ChatMessage[] temporaryMemory = [systemMessage, userMessage];
     ChatAssistantMessage? finalAssistantMessage = ();
     int iter = 0;
-    foreach ExecutionResult|LlmChatResponse|ExecutionError|Error step in executor {
+    foreach ExecutionResult|string|ExecutionError|Error step in executor {
         ChatAssistantMessage|ChatFunctionMessage|Error iterationOutput = getOutputOfIteration(step);
         ChatMessage[] iterationHistory = buildCurrentIterationHistory(executor.progress, history);
         if verbose {
@@ -373,29 +365,29 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
         }
         if iter == maxIter {
             log:printDebug("Maximum iterations reached without final answer",
-                agentId = agentId,
-                executionId = executionId,
-                iterations = iter,
-                stepsCompleted = steps.length(),
-                sessionId = sessionId
+                    agentId = agentId,
+                    executionId = executionId,
+                    iterations = iter,
+                    stepsCompleted = steps.length(),
+                    sessionId = sessionId
             );
             break;
         }
         if step is ExecutionError && step.'error is UnauthorizedError {
             error err = step.'error;
             content = "I could not complete your request due to an authorization issue, " +
-              "possibly related to the access token or its permissions. Please check that your " 
-              + "credentials are valid and have the required access, then try again";
-            Error newError =  error Error(content.toString(), 'error = err); 
+            "possibly related to the access token or its permissions. Please check that your "
+            + "credentials are valid and have the required access, then try again";
+            Error newError = error Error(content.toString(), 'error = err);
             iterationOutput = newError;
             if verbose {
-                verbosePrint(newError, iter); 
+                verbosePrint(newError, iter);
             }
             log:printDebug("Tool execution failed: ",
-                err,
-                executionId = executionId,
-                iteration = iter,
-                sessionId = sessionId
+                    err,
+                    executionId = executionId,
+                    iteration = iter,
+                    sessionId = sessionId
             );
             steps.push(step);
             finalAssistantMessage = {role: ASSISTANT, content: content};
@@ -415,14 +407,14 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
             iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
             break;
         }
-        if step is LlmChatResponse {
-            content = step.content;
+        if step is string {
+            content = step;
             log:printDebug("Final answer generated by agent",
-                agentId = agentId,
-                executionId = executionId,
-                iteration = iter,
-                answer = content,
-                sessionId = sessionId
+                    agentId = agentId,
+                    executionId = executionId,
+                    iteration = iter,
+                    answer = content,
+                    sessionId = sessionId
             );
             finalAssistantMessage = {role: ASSISTANT, content: content};
             iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
@@ -430,12 +422,12 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
         }
         iter += 1;
         log:printDebug("Agent iteration started",
-            agentId = agentId,
-            executionId = executionId,
-            iteration = iter,
-            maxIterations = maxIter,
-            stepsCompleted = steps.length(),
-            sessionId = sessionId
+                agentId = agentId,
+                executionId = executionId,
+                iteration = iter,
+                maxIterations = maxIter,
+                stepsCompleted = steps.length(),
+                sessionId = sessionId
         );
         steps.push(step);
         iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
@@ -468,10 +460,10 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
     return {steps, iterations, answer: content, toolCalls};
 }
 
-isolated function verbosePrint(ExecutionResult|LlmChatResponse|ExecutionError|Error step, int iter) {
+isolated function verbosePrint(ExecutionResult|string|ExecutionError|Error step, int iter) {
     io:println(string `${"\n\n"}Agent Iteration ${iter.toString()}`);
-    if step is LlmChatResponse {
-        io:println(string `${"\n\n"}Final Answer: ${step.content}${"\n\n"}`);
+    if step is string {
+        io:println(string `${"\n\n"}Final Answer: ${step}${"\n\n"}`);
         return;
     }
     if step is ExecutionResult {
@@ -505,13 +497,13 @@ isolated function verbosePrint(ExecutionResult|LlmChatResponse|ExecutionError|Er
     }
 }
 
-isolated function getOutputOfIteration(ExecutionResult|LlmChatResponse|ExecutionError|Error step)
+isolated function getOutputOfIteration(ExecutionResult|string|ExecutionError|Error step)
     returns ChatAssistantMessage|ChatFunctionMessage|Error {
     if step is Error {
         return step;
     }
-    if step is LlmChatResponse {
-        return {role: ASSISTANT, content: step.content};
+    if step is string {
+        return {role: ASSISTANT, content: step};
     }
     if step is ExecutionError {
         return step.'error;

--- a/ballerina/agent.bal
+++ b/ballerina/agent.bal
@@ -169,34 +169,13 @@ public isolated distinct class Agent {
         }
     }
 
-    # Parse the function calling API response and extract the tool to be executed.
-    #
-    # + llmResponse - Raw LLM response
-    # + return - A record containing the tool decided by the LLM, chat response or an error if the response is invalid
-    isolated function parseLlmResponse(json llmResponse) returns LlmToolResponse|LlmChatResponse|LlmInvalidGenerationError {
-        if llmResponse is string {
-            return {content: llmResponse};
-        }
-        if llmResponse !is FunctionCall {
-            return error LlmInvalidGenerationError("Invalid response", llmResponse = llmResponse);
-        }
-        string? name = llmResponse.name;
-        if name is () {
-            return error LlmInvalidGenerationError("Missing name", name = llmResponse.name, arguments = llmResponse.arguments);
-        }
-        return {
-            name,
-            arguments: llmResponse.arguments,
-            id: llmResponse.id
-        };
-    }
-
     # Use LLM to decide the next tool/step based on the function calling APIs.
     #
     # + progress - Execution progress with the current query and execution history
     # + sessionId - The ID associated with the agent memory
     # + return - LLM response containing the tool or chat response (or an error if the call fails)
-    isolated function selectNextTool(ExecutionProgress progress, string sessionId = DEFAULT_SESSION_ID) returns json|Error {
+    isolated function selectNextTool(ExecutionProgress progress, string sessionId = DEFAULT_SESSION_ID)
+    returns FunctionCall[]|string|Error {
         ChatMessage[] messages = check createFunctionCallMessages(progress);
         messages.unshift(...progress.history);
         ToolLoadingStrategy toolLoadingStrategy = self.toolLoadingStrategy;
@@ -222,20 +201,21 @@ public isolated distinct class Agent {
                 availableTools = filteredTools.toString()
         );
 
-        // TODO: Improve handling of multiple tool calls returned by the LLM.
-        // Currently, tool calls are executed sequentially in separate chat responses.
-        // Update the logic to execute all tool calls together and return a single response.
         ChatAssistantMessage response = check self.model->chat(messages, filteredTools);
-        FunctionCall? toolCall = getFirstToolCall(response);
-
-        if toolCall is FunctionCall {
-            log:printDebug("LLM selected tool",
+        // All tool calls returned in this single LLM response are executed together
+        // (see `Executor.next()`) before the LLM is consulted again, instead of executing
+        // them one at a time across separate chat requests.
+        FunctionCall[]? toolCalls = getToolCalls(response);
+        if toolCalls is FunctionCall[] {
+            log:printDebug("LLM selected tool(s)",
                     executionId = progress.executionId,
                     sessionId = sessionId,
-                    toolName = toolCall.name,
-                    toolArguments = toolCall.arguments
+                    toolNames = from FunctionCall toolCall in toolCalls
+                        select toolCall.name,
+                    toolArguments = from FunctionCall toolCall in toolCalls
+                        select toolCall.arguments
             );
-            return toolCall;
+            return toolCalls;
         }
 
         log:printDebug("LLM provided chat response instead of tool call",
@@ -243,7 +223,17 @@ public isolated distinct class Agent {
                 sessionId = sessionId,
                 response = response?.content
         );
-        return response?.content;
+        string? content = response?.content;
+        if content is string {
+            return content;
+        }
+        log:printDebug("Failed to parse LLM response as valid tool or chat",
+                agentId = self.agentId,
+                executionId = progress.executionId,
+                sessionId = sessionId
+        );
+        return error LlmInvalidGenerationError("Failed to parse the LLM response into a function call or chat message.",
+            llmResponse = content);
     }
 
     # Executes the agent for a given user query.
@@ -285,7 +275,7 @@ public isolated distinct class Agent {
         Credential? & readonly agentCredential = self.agentCredential;
         string? agentId = agentCredential is Credential ? agentCredential.id : ();
         ExecutionTrace executionTrace = run(self, systemPrompt, query, self.maxIter, self.verbose, agentId,
-            sessionId, context, executionId);
+                sessionId, context, executionId);
         ChatUserMessage userMessage = {role: USER, content: query};
         Iteration[] iterations = executionTrace.iterations;
         FunctionCall[]? toolCalls = executionTrace.toolCalls.length() == 0 ? () : executionTrace.toolCalls;

--- a/ballerina/function-call-utils.bal
+++ b/ballerina/function-call-utils.bal
@@ -163,10 +163,10 @@ isolated function lazyLoadTools(ChatMessage[] messages, ChatCompletionFunctions[
     return;
 }
 
-isolated function getFirstToolCall(ChatAssistantMessage msg) returns FunctionCall? {
+isolated function getToolCalls(ChatAssistantMessage msg) returns FunctionCall[]? {
     FunctionCall[]? toolCalls = msg?.toolCalls;
     if toolCalls is () || toolCalls.length() == 0 {
         return;
     }
-    return toolCalls[0];
+    return toolCalls;
 }

--- a/ballerina/tests/agent-test.bal
+++ b/ballerina/tests/agent-test.bal
@@ -1,3 +1,19 @@
+// Copyright (c) 2026 WSO2 LLC (http://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/test;
 
 ToolConfig searchTool = {
@@ -46,15 +62,15 @@ function testAgentExecutorRun() returns error? {
         instruction = "Answer the questions", query = query, context = new, executionId = DEFAULT_EXECUTION_ID,
         history = []
     );
-    record {|ExecutionResult|LlmChatResponse|ExecutionError|Error value;|}? result = agentExecutor.next();
+    record {|ExecutionResult|string|ExecutionError|Error value;|}? result = agentExecutor.next();
     if result is () {
         test:assertFail("AgentExecutor.next returns an null during first iteration");
     }
-    ExecutionResult|LlmChatResponse|ExecutionError|Error output = result.value;
+    ExecutionResult|string|ExecutionError|Error output = result.value;
     if output is Error {
         test:assertFail("AgentExecutor.next returns an error during first iteration");
     }
-    test:assertEquals(output?.observation, "Camila Morrone");
+    test:assertEquals(output, "Camila Morrone");
 
     result = agentExecutor.next();
     if result is () {
@@ -64,7 +80,7 @@ function testAgentExecutorRun() returns error? {
     if output is Error {
         test:assertFail("AgentExecutor.next returns an error during second iteration");
     }
-    test:assertEquals(output?.observation, "25 years");
+    test:assertEquals(output, "25 years");
 
     result = agentExecutor.next();
     if result is () {
@@ -74,7 +90,7 @@ function testAgentExecutorRun() returns error? {
     if output is Error {
         test:assertFail("AgentExecutor.next returns an error during third iteration");
     }
-    test:assertEquals(output?.observation, "Answer: 3.991298452658078");
+    test:assertEquals(output, "Answer: 3.991298452658078");
 }
 
 @test:Config
@@ -113,7 +129,7 @@ function testAgentRecoversFromBadlyFormattedHistoryWithoutCorruptingMemory() ret
     test:assertTrue(secondResult is Error);
     if secondResult is Error {
         string detail = secondResult.detail().toString();
-        test:assertEquals(detail.includes("Failed to parse a persisted execution step into a function call"), true);
+        test:assertTrue(detail.includes("Failed to parse the LLM response into a function call or chat message."));
     }
 
     // Turn 3: a normal exchange again, using the same session. If the failed turn had persisted

--- a/ballerina/tests/agent-test.bal
+++ b/ballerina/tests/agent-test.bal
@@ -137,3 +137,60 @@ function testAgentRecoversFromBadlyFormattedHistoryWithoutCorruptingMemory() ret
     string thirdResult = check agent.run("third turn query");
     test:assertEquals(thirdResult, "third turn answer");
 }
+
+@test:Config
+function testAgentRunExecutesMultipleToolCallsFromSingleLlmResponseTogether() returns error? {
+    MultiToolCallMockLLM scriptedModel = new;
+    Agent agent = check new ({
+        systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
+        model: scriptedModel,
+        tools: [searchTool, calculatorTool]
+    });
+
+    // The mock LLM returns both the `Search` and `Calculator` tool calls together in a single
+    // response. The agent must execute both before consulting the LLM again, and the LLM then
+    // answers both questions at once in a single final response.
+    Trace trace = check agent.run("Who is Leo DiCaprio's girlfriend, and what is 25 raised to the power of 0.43?",
+            td = Trace);
+
+    // Final answer covers both questions, generated from a single follow-up LLM call.
+    ChatAssistantMessage|Error output = trace.output;
+    test:assertTrue(output is ChatAssistantMessage);
+    if output is ChatAssistantMessage {
+        test:assertEquals(output.content, "Leo DiCaprio's girlfriend is Camila Morrone, and 25 raised to the " +
+                "power of 0.43 is Answer: 3.991298452658078");
+    }
+
+    // Both tool calls from the single LLM response were captured and executed.
+    FunctionCall[]? toolCalls = trace.toolCalls;
+    test:assertTrue(toolCalls is FunctionCall[]);
+    if toolCalls is FunctionCall[] {
+        test:assertEquals(toolCalls.length(), 2);
+        test:assertEquals(toolCalls[0].name, "Search");
+        test:assertEquals(toolCalls[1].name, "Calculator");
+    }
+
+    // Intermediate tool observations are present, one iteration per tool call, followed by the
+    // final answer iteration.
+    test:assertEquals(trace.iterations.length(), 3);
+    ChatAssistantMessage|ChatFunctionMessage|Error searchIterationOutput = trace.iterations[0].output;
+    test:assertTrue(searchIterationOutput is ChatFunctionMessage);
+    if searchIterationOutput is ChatFunctionMessage {
+        test:assertEquals(searchIterationOutput.name, "Search");
+        test:assertEquals(searchIterationOutput.content, "Camila Morrone");
+    }
+    ChatAssistantMessage|ChatFunctionMessage|Error calculatorIterationOutput = trace.iterations[1].output;
+    test:assertTrue(calculatorIterationOutput is ChatFunctionMessage);
+    if calculatorIterationOutput is ChatFunctionMessage {
+        test:assertEquals(calculatorIterationOutput.name, "Calculator");
+        test:assertEquals(calculatorIterationOutput.content, "Answer: 3.991298452658078");
+    }
+    ChatAssistantMessage|ChatFunctionMessage|Error finalIterationOutput = trace.iterations[2].output;
+    test:assertTrue(finalIterationOutput is ChatAssistantMessage);
+
+    // Only 2 LLM calls were made: one that returned both tool calls together, and one that
+    // produced the final answer after both tool results were available. Previously, executing
+    // 2 tool calls required 3 LLM calls, one per tool call plus the final answer, because only
+    // the first tool call in a response was ever acted on.
+    test:assertEquals(scriptedModel.getChatCallCount(), 2);
+}

--- a/ballerina/tests/mock-tools.bal
+++ b/ballerina/tests/mock-tools.bal
@@ -94,6 +94,54 @@ public isolated client class ScriptedMockLLM {
     isolated remote function generate(Prompt prompt, typedesc<anydata> td = <>) returns td|Error = external;
 }
 
+// Returns both the `Search` and `Calculator` tool calls together in a single response, then, once
+// both tool results are present in the conversation history, returns the final answer.
+// Used to verify that multiple tool calls returned in one LLM response are all executed before the
+// LLM is consulted again, instead of one round-trip per tool call.
+public isolated client class MultiToolCallMockLLM {
+    *ModelProvider;
+
+    private int chatCallCount = 0;
+
+    isolated remote function chat(ChatMessage[]|ChatUserMessage messages, ChatCompletionFunctions[] tools = [],
+            string? stop = ()) returns ChatAssistantMessage|Error {
+        lock {
+            self.chatCallCount += 1;
+        }
+        int toolResultCount = messages is ChatUserMessage ? 0
+            : messages.filter(msg => msg is ChatFunctionMessage).length();
+        if toolResultCount == 0 {
+            return {
+                role: ASSISTANT,
+                toolCalls: [
+                    {name: "Search", arguments: {params: {query: "Leo DiCaprio girlfriend"}}, id: "call-1"},
+                    {name: "Calculator", arguments: {params: {expression: "25 ^ 0.43"}}, id: "call-2"}
+                ]
+            };
+        }
+        if toolResultCount == 2 {
+            return {
+                role: ASSISTANT,
+                content: "Leo DiCaprio's girlfriend is Camila Morrone, and 25 raised to the power of 0.43 is " +
+                    "Answer: 3.991298452658078"
+            };
+        }
+        return error Error("Unexpected number of tool results in history: " + toolResultCount.toString());
+    }
+
+    isolated remote function generate(Prompt prompt, typedesc<anydata> td = <>) returns td|Error = external;
+
+    # Returns the number of times the LLM was consulted, so that tests can assert
+    # all the tool calls from one response were executed without extra round-trips.
+    #
+    # + return - The number of times `chat` has been called
+    public isolated function getChatCallCount() returns int {
+        lock {
+            return self.chatCallCount;
+        }
+    }
+}
+
 isolated function getChatAssistantMessageContent(int queryLevel) returns string|LlmError {
     match queryLevel {
         3 => {

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,9 @@ This file documents all significant changes made to the Ballerina AI package acr
 - [Fix `maxIter` Inference with Toolkits and Enforce Minimum of 10](https://github.com/wso2/product-integrator/issues/1112)
 - [Fix OpenAPI Spec Defaulting to Port 9090 When an AI Agent Listener Uses an Inline `http:Listener`](https://github.com/wso2/product-integrator/issues/1676)
 
+### Updated
+- [Execute Multiple Tool Calls Returned in a Single LLM Response Together](https://github.com/wso2/product-integrator/issues/1833)
+
 ## [1.11.1] - 2026-04-16
 
 ### Fixed

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/01_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/02_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/03_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/03_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/04_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/04_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/05_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/05_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/06_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/06_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/07_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/07_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/08_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/08_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/09_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/09_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/10_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/10_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/11_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/11_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/12_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/12_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/13_sample/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/openapi_tests/13_sample/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/01_tool_with_any_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/02_tool_with_any_return_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/03_tool_with_xml_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/04_tool_with_cyclic_input_type/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/05_error_lines_no_change/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/06_module_level_agent_without_final_qualifier/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/07_tool_with_context_in_invalid_position/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/07_tool_with_context_in_invalid_position/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/08_local_tool_with_scope_annotation/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/ballerina_sources/validation_tests/08_local_tool_with_scope_annotation/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "ai_tests"
-version = "1.11.2"
+version = "1.12.0"
 
 [build-options]
 observabilityIncluded = true
@@ -9,12 +9,12 @@ observabilityIncluded = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "ai-native"
-version = "1.11.2"
-path = "../../../../../../../native/build/libs/ai-native-1.11.2-SNAPSHOT-tests.jar"
+version = "1.12.0"
+path = "../../../../../../../native/build/libs/ai-native-1.12.0-SNAPSHOT-tests.jar"
 testOnly = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=1.11.2-SNAPSHOT
+version=1.12.0-SNAPSHOT
 ballerinaLangVersion=2201.12.0
 
 ballerinaGradlePluginVersion=3.0.0


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-integrator/issues/1833

<img width="908" height="934" alt="image" src="https://github.com/user-attachments/assets/4ce563b1-fa92-47cc-98d4-e784066d7b0b" />

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the agent to execute all tool calls returned in a single LLM response together (buffering multi-tool requests) before making the next model call, replacing the prior single-tool-call flow. This includes refactoring response parsing and iteration/execution logic to return and process either a final chat answer or a full set of tool calls, updating related executor/utilities, and improving how final outputs are formatted.

Added a dedicated test and a mock LLM to verify that multiple tool calls from one LLM response are executed (both tool calls captured and invoked) and that the final combined answer is produced correctly, with fewer model round-trips.

Refreshed the changelog entry for the updated behavior and bumped project/platform/test artifact versions to 1.12.0-SNAPSHOT (including associated test resource configurations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->