### PR TITLE
Add agent configuration to execute tool calls in parallel

### DIFF
--- a/ballerina/agent-utils.bal
+++ b/ballerina/agent-utils.bal
@@ -90,6 +90,9 @@ class Executor {
     # All of them are executed before the LLM is reasoned with again, so that a single
     # LLM response containing multiple tool calls does not trigger multiple round-trips.
     private FunctionCall[] pendingToolCalls = [];
+    # Results of tool calls that were already executed in parallel but not yet
+    # handed out through the iterator, one result per iteration.
+    private (ExecutionResult|ExecutionError)[] executedToolCallResults = [];
 
     # Initialize the executor with the agent and the query.
     #
@@ -131,14 +134,16 @@ class Executor {
                 sessionId = self.sessionId,
                 history = self.progress.executionSteps.toString()
         );
-        return check self.agent.selectNextTool(self.progress, self.sessionId);
+        return check self.agent.selectNextTools(self.progress, self.sessionId);
     }
 
     # Execute the next step of the agent.
     #
-    # + llmResponse - LLM response containing the tool to be executed and the raw LLM output
+    # + llmResponse - LLM response containing a chat response, the tool to be executed, or
+    # multiple tools to be executed in parallel
     # + return - Observations from the tool can be any|error|null
-    public isolated function act(FunctionCall|string llmResponse) returns ExecutionResult|string|ExecutionError {
+    public isolated function act(FunctionCall[]|FunctionCall|string llmResponse)
+            returns ExecutionResult|string|ExecutionError {
         if llmResponse is string {
             log:printDebug("Parsed LLM response as chat response",
                     agentId = self.agentId,
@@ -149,115 +154,59 @@ class Executor {
             self.isCompleted = true;
             return llmResponse;
         }
+        return llmResponse is FunctionCall
+            ? self.executeToolCalls([llmResponse], parallel = false)
+            : self.executeToolCalls(llmResponse, parallel = self.agent.allowParallelToolCall);
+    }
 
-        anydata observation;
-        ExecutionResult|ExecutionError executionResult;
-        string toolName = llmResponse.name;
-        log:printDebug("Parsed LLM response as tool call",
-                agentId = self.agentId,
-                executionId = self.progress.executionId,
-                sessionId = self.sessionId,
-                toolName = toolName,
-                arguments = llmResponse.arguments
-            );
-        observe:ExecuteToolSpan span = observe:createExecuteToolSpan(toolName);
-        string? toolCallId = llmResponse.id;
-        if toolCallId is string {
-            span.addId(toolCallId);
+    private isolated function executeToolCalls(FunctionCall[] toolCalls, boolean parallel)
+            returns ExecutionResult|ExecutionError {
+        [ExecutionResult|ExecutionError, anydata][] executionOutcomes = parallel
+            ? self.executeToolCallsParallelly(toolCalls)
+            : self.executeToolCallsSequentially(toolCalls);
+        foreach int i in 0 ..< executionOutcomes.length() {
+            var [executionResult, observation] = executionOutcomes[i];
+            self.update({llmResponse: toolCalls[i], observation});
+            self.executedToolCallResults.push(executionResult);
         }
-        ToolStore toolStore = self.agent.toolStore;
-        string? toolDescription = toolStore.getToolDescription(toolName);
-        if toolDescription is string {
-            span.addDescription(toolDescription);
+        return self.executedToolCallResults.shift();
+    }
+
+    private isolated function executeToolCallsParallelly(FunctionCall[] toolCalls)
+            returns [ExecutionResult|ExecutionError, anydata][] {
+        final Agent agent = self.agent;
+        final Context context = self.progress.context;
+        final string? agentId = self.agentId;
+        final string executionId = self.progress.executionId;
+        final string sessionId = self.sessionId;
+        future<[ExecutionResult|ExecutionError, anydata]>[] executions = [];
+        foreach FunctionCall toolCall in toolCalls {
+            final readonly & FunctionCall clonedToolCall = toolCall.cloneReadOnly();
+            var execution = start executeToolCall(agent, clonedToolCall, context, agentId, executionId, sessionId);
+            executions.push(execution);
         }
-        boolean isMcpTool = toolStore.isMcpTool(toolName);
-        span.addType(isMcpTool ? observe:EXTENTION : observe:FUNCTION);
-        span.addArguments(llmResponse.arguments);
-        ToolNotFoundError|ToolInvalidInputError|TokenAcquisitionError|TokenValidationError?
-                    validateRes = validateTool(llmResponse, self.agent.agentCredential,
-                self.agent.tokenManager, self.progress.context, toolStore.tools, isMcpTool);
-        if validateRes is Error {
-            log:printError("Tool validation failed",
-                    agentId = self.agentId,
-                    executionId = self.progress.executionId,
-                    sessionId = self.sessionId,
-                    toolName = toolName,
-                    'error = validateRes
-                );
-            if validateRes is ToolNotFoundError|ToolInvalidInputError {
-                observation = "Tool extraction failed due to tool validation";
-                executionResult = {
-                    llmResponse,
-                    'error: validateRes,
-                    observation: observation.toString()
-                };
-                Error toolExecutionError = error Error(observation.toString(), details = {llmResponse});
-                span.close(toolExecutionError);
-            } else {
-                observation = "Tool execution failed while attempting to execute the selected tool: "
-                        + validateRes.message();
-                executionResult = {
-                    llmResponse,
-                    'error: error UnauthorizedError(
-                            string `Tool execution failed: ${validateRes.message()}`,
-                            details = {llmResponse}, cause = validateRes.cause(), toolName = toolName),
-                    observation: observation.toString()
-                };
-                UnauthorizedError toolExecutionError = error UnauthorizedError(observation.toString(),
-                        details = {llmResponse});
-                span.close(toolExecutionError);
+        [ExecutionResult|ExecutionError, anydata][] executionOutcomes = [];
+        foreach var execution in executions {
+            [ExecutionResult|ExecutionError, anydata]|error executionOutcome = wait execution;
+            if executionOutcome is error {
+                // `executeToolCall` never returns an error; a waiting error means the strand
+                // terminated abnormally, which mirrors a panic during sequential execution.
+                panic executionOutcome;
             }
-        } else {
-            ToolOutput|ToolExecutionError|LlmInvalidGenerationError output = toolStore.execute(llmResponse,
-                    self.progress.context);
-            if output is Error {
-                if output is ToolNotFoundError {
-                    observation = "Tool is not found. Please check the tool name and retry.";
-                } else if output is ToolInvalidInputError {
-                    observation = "Tool execution failed due to invalid inputs. Retry with correct inputs.";
-                } else {
-                    observation = "Tool execution failed. Retry with correct inputs.";
-                }
-                observation = string `${observation.toString()} <detail>${output.toString()}</detail>`;
-                executionResult = {
-                    llmResponse,
-                    'error: output,
-                    observation: observation.toString()
-                };
-                log:printError("Tool execution resulted in error",
-                        agentId = self.agentId,
-                        executionId = self.progress.executionId,
-                        observation = observation.toString(),
-                        sessionId = self.sessionId,
-                        toolName = toolName
-                    );
-
-                Error toolExecutionError = error Error(observation.toString(), details = {llmResponse});
-                span.close(toolExecutionError);
-            } else {
-                anydata|error value = output.value;
-                observation = value is error ? value.toString() : value;
-                log:printDebug("Tool execution successful",
-                        agentId = self.agentId,
-                        executionId = self.progress.executionId,
-                        sessionId = self.sessionId,
-                        toolName = toolName
-                    );
-                executionResult = {
-                    tool: llmResponse,
-                    observation: value
-                };
-
-                span.addOutput(observation);
-                span.close();
-            }
+            executionOutcomes.push(executionOutcome);
         }
+        return executionOutcomes;
+    }
 
-        self.update({
-            llmResponse,
-            observation
-        });
-        return executionResult;
+    private isolated function executeToolCallsSequentially(FunctionCall[] toolCalls)
+            returns [ExecutionResult|ExecutionError, anydata][] {
+        [ExecutionResult|ExecutionError, anydata][] executionOutcomes = [];
+        foreach FunctionCall toolCall in toolCalls {
+            var executionOutcome = executeToolCall(self.agent, toolCall, self.progress.context,
+                    self.agentId, self.progress.executionId, self.sessionId);
+            executionOutcomes.push(executionOutcome);
+        }
+        return executionOutcomes;
     }
 
     # Update the agent with an execution step.
@@ -283,6 +232,9 @@ class Executor {
         if self.isCompleted {
             return ();
         }
+        if self.executedToolCallResults.length() > 0 {
+            return {value: self.executedToolCallResults.shift()};
+        }
         if self.pendingToolCalls.length() == 0 {
             FunctionCall[]|string|Error llmResponse = self.reason();
             if llmResponse is Error {
@@ -295,9 +247,120 @@ class Executor {
                 self.pendingToolCalls = llmResponse;
             }
         }
+        if self.agent.allowParallelToolCall && self.pendingToolCalls.length() > 1 {
+            FunctionCall[] toolCalls = self.pendingToolCalls;
+            self.pendingToolCalls = [];
+            return {value: self.act(toolCalls)};
+        }
         FunctionCall nextToolCall = self.pendingToolCalls.shift();
         return {value: self.act(nextToolCall)};
     }
+}
+
+isolated function executeToolCall(Agent agent, FunctionCall llmResponse, Context context, string? agentId,
+        string executionId, string sessionId) returns [ExecutionResult|ExecutionError, anydata] {
+    anydata observation;
+    ExecutionResult|ExecutionError executionResult;
+    string toolName = llmResponse.name;
+    log:printDebug("Parsed LLM response as tool call",
+            agentId = agentId,
+            executionId = executionId,
+            sessionId = sessionId,
+            toolName = toolName,
+            arguments = llmResponse.arguments
+        );
+    observe:ExecuteToolSpan span = observe:createExecuteToolSpan(toolName);
+    string? toolCallId = llmResponse.id;
+    if toolCallId is string {
+        span.addId(toolCallId);
+    }
+    ToolStore toolStore = agent.toolStore;
+    string? toolDescription = toolStore.getToolDescription(toolName);
+    if toolDescription is string {
+        span.addDescription(toolDescription);
+    }
+    boolean isMcpTool = toolStore.isMcpTool(toolName);
+    span.addType(isMcpTool ? observe:EXTENTION : observe:FUNCTION);
+    span.addArguments(llmResponse.arguments);
+    ToolNotFoundError|ToolInvalidInputError|TokenAcquisitionError|TokenValidationError?
+                validateRes = validateTool(llmResponse, agent.agentCredential,
+            agent.tokenManager, context, toolStore.tools, isMcpTool);
+    if validateRes is Error {
+        log:printError("Tool validation failed",
+                agentId = agentId,
+                executionId = executionId,
+                sessionId = sessionId,
+                toolName = toolName,
+                'error = validateRes
+            );
+        if validateRes is ToolNotFoundError|ToolInvalidInputError {
+            observation = "Tool extraction failed due to tool validation";
+            executionResult = {
+                llmResponse,
+                'error: validateRes,
+                observation: observation.toString()
+            };
+            Error toolExecutionError = error Error(observation.toString(), details = {llmResponse});
+            span.close(toolExecutionError);
+        } else {
+            observation = "Tool execution failed while attempting to execute the selected tool: "
+                    + validateRes.message();
+            executionResult = {
+                llmResponse,
+                'error: error UnauthorizedError(
+                        string `Tool execution failed: ${validateRes.message()}`,
+                        details = {llmResponse}, cause = validateRes.cause(), toolName = toolName),
+                observation: observation.toString()
+            };
+            UnauthorizedError toolExecutionError = error UnauthorizedError(observation.toString(),
+                    details = {llmResponse});
+            span.close(toolExecutionError);
+        }
+    } else {
+        ToolOutput|ToolExecutionError|LlmInvalidGenerationError output = toolStore.execute(llmResponse, context);
+        if output is Error {
+            if output is ToolNotFoundError {
+                observation = "Tool is not found. Please check the tool name and retry.";
+            } else if output is ToolInvalidInputError {
+                observation = "Tool execution failed due to invalid inputs. Retry with correct inputs.";
+            } else {
+                observation = "Tool execution failed. Retry with correct inputs.";
+            }
+            observation = string `${observation.toString()} <detail>${output.toString()}</detail>`;
+            executionResult = {
+                llmResponse,
+                'error: output,
+                observation: observation.toString()
+            };
+            log:printError("Tool execution resulted in error",
+                    agentId = agentId,
+                    executionId = executionId,
+                    observation = observation.toString(),
+                    sessionId = sessionId,
+                    toolName = toolName
+                );
+
+            Error toolExecutionError = error Error(observation.toString(), details = {llmResponse});
+            span.close(toolExecutionError);
+        } else {
+            anydata|error value = output.value;
+            observation = value is error ? value.toString() : value;
+            log:printDebug("Tool execution successful",
+                    agentId = agentId,
+                    executionId = executionId,
+                    sessionId = sessionId,
+                    toolName = toolName
+                );
+            executionResult = {
+                tool: llmResponse,
+                observation: value
+            };
+
+            span.addOutput(observation);
+            span.close();
+        }
+    }
+    return [executionResult, observation];
 }
 
 # Execute the agent for a given user's query.

--- a/ballerina/agent-utils.bal
+++ b/ballerina/agent-utils.bal
@@ -156,7 +156,7 @@ class Executor {
         }
         return llmResponse is FunctionCall
             ? self.executeToolCalls([llmResponse], parallel = false)
-            : self.executeToolCalls(llmResponse, parallel = self.agent.allowParallelToolCall);
+            : self.executeToolCalls(llmResponse, parallel = self.agent.executeToolCallsInParallel);
     }
 
     private isolated function executeToolCalls(FunctionCall[] toolCalls, boolean parallel)
@@ -247,7 +247,7 @@ class Executor {
                 self.pendingToolCalls = llmResponse;
             }
         }
-        if self.agent.allowParallelToolCall && self.pendingToolCalls.length() > 1 {
+        if self.agent.executeToolCallsInParallel && self.pendingToolCalls.length() > 1 {
             FunctionCall[] toolCalls = self.pendingToolCalls;
             self.pendingToolCalls = [];
             return {value: self.act(toolCalls)};

--- a/ballerina/agent-utils.bal
+++ b/ballerina/agent-utils.bal
@@ -77,7 +77,9 @@ public type ToolOutput record {|
     anydata|error value;
 |};
 
-# An executor to perform step-by-step execution of the agent.
+# An executor that runs the agent's reasoning-action cycles one at a time.
+# Each iteration is a complete cycle: one LLM call (reason) followed by the
+# execution of every tool call returned in that response (act).
 class Executor {
     *object:Iterable;
     private boolean isCompleted = false;
@@ -86,23 +88,22 @@ class Executor {
     # Contains the current execution progress for the agent and the query
     public ExecutionProgress progress;
     private string? agentId = ();
-    # Tool calls from the LLM's latest response that are still pending execution.
-    # All of them are executed before the LLM is reasoned with again, so that a single
-    # LLM response containing multiple tool calls does not trigger multiple round-trips.
-    private FunctionCall[] pendingToolCalls = [];
-    # Results of tool calls that were already executed in parallel but not yet
-    # handed out through the iterator, one result per iteration.
-    private (ExecutionResult|ExecutionError)[] executedToolCallResults = [];
+    # Number of reasoning-action cycles the executor may still run.
+    private int remainingIterations;
+    # Set when the executor stops because the iteration limit was reached without a final answer.
+    private boolean maxIterationsExceeded = false;
 
     # Initialize the executor with the agent and the query.
     #
     # + agent - Agent instance to be executed
+    # + maxIter - Maximum number of reasoning-action cycles allowed for this execution
     # + query - Natural language query to be executed by the agent
     # + history - Execution history of the agent (This is used to continue an execution paused without completing)
     # + context - Contextual information to be used by the tools during the execution
-    isolated function init(Agent agent, string sessionId, *ExecutionProgress progress) {
+    isolated function init(Agent agent, string sessionId, int maxIter, *ExecutionProgress progress) {
         self.sessionId = sessionId;
         self.agent = agent;
+        self.remainingIterations = maxIter;
         self.progress = progress;
         Credential? agentCredential = agent.agentCredential;
         if agentCredential is Credential {
@@ -137,13 +138,12 @@ class Executor {
         return check self.agent.selectNextTools(self.progress, self.sessionId);
     }
 
-    # Execute the next step of the agent.
+    # Execute the action decided by the LLM during the reasoning.
     #
-    # + llmResponse - LLM response containing a chat response, the tool to be executed, or
-    # multiple tools to be executed in parallel
-    # + return - Observations from the tool can be any|error|null
-    public isolated function act(FunctionCall[]|FunctionCall|string llmResponse)
-            returns ExecutionResult|string|ExecutionError {
+    # + llmResponse - LLM response containing a chat response or the tool calls to be executed
+    # + return - Results of every executed tool call, or the final chat response
+    public isolated function act(FunctionCall[]|string llmResponse)
+            returns (ExecutionResult|ExecutionError)[]|string {
         if llmResponse is string {
             log:printDebug("Parsed LLM response as chat response",
                     agentId = self.agentId,
@@ -154,22 +154,22 @@ class Executor {
             self.isCompleted = true;
             return llmResponse;
         }
-        return llmResponse is FunctionCall
-            ? self.executeToolCalls([llmResponse], parallel = false)
-            : self.executeToolCalls(llmResponse, parallel = self.agent.executeToolCallsInParallel);
+        boolean isParallel = self.agent.executeToolCallsInParallel && llmResponse.length() > 1;
+        return self.executeToolCalls(llmResponse, isParallel);
     }
 
-    private isolated function executeToolCalls(FunctionCall[] toolCalls, boolean parallel)
-            returns ExecutionResult|ExecutionError {
-        [ExecutionResult|ExecutionError, anydata][] executionOutcomes = parallel
+    private isolated function executeToolCalls(FunctionCall[] toolCalls, boolean isParallel)
+            returns (ExecutionResult|ExecutionError)[] {
+        [ExecutionResult|ExecutionError, anydata][] executionOutcomes = isParallel
             ? self.executeToolCallsParallelly(toolCalls)
             : self.executeToolCallsSequentially(toolCalls);
+        (ExecutionResult|ExecutionError)[] executionResults = [];
         foreach int i in 0 ..< executionOutcomes.length() {
             var [executionResult, observation] = executionOutcomes[i];
             self.update({llmResponse: toolCalls[i], observation});
-            self.executedToolCallResults.push(executionResult);
+            executionResults.push(executionResult);
         }
-        return self.executedToolCallResults.shift();
+        return executionResults;
     }
 
     private isolated function executeToolCallsParallelly(FunctionCall[] toolCalls)
@@ -216,44 +216,46 @@ class Executor {
         self.progress.executionSteps.push(step);
     }
 
-    # Iterate over the agent's execution steps.
+    # Iterate over the agent's reasoning-action cycles.
     #
-    # + return - a record with the execution step or an error if the agent failed
+    # + return - a record with the results of a reasoning-action cycle or an error if the agent failed
     public function iterator() returns object {
-        public function next() returns record {|ExecutionResult|string|ExecutionError|Error value;|}?;
+        public function next() returns record {|(ExecutionResult|ExecutionError)[]|string|Error value;|}?;
     } {
         return self;
     }
 
-    # Reason and execute the next step of the agent.
+    # Run the next reasoning-action cycle of the agent: reason with the LLM once and
+    # execute every tool call returned in that response.
     #
-    # + return - A record with ExecutionResult, chat response or an error 
-    public isolated function next() returns record {|ExecutionResult|string|ExecutionError|Error value;|}? {
+    # + return - A record with the results of the executed tool calls, the final chat
+    # response, or an error; nil once the execution has completed
+    public isolated function next() returns record {|(ExecutionResult|ExecutionError)[]|string|Error value;|}? {
         if self.isCompleted {
             return ();
         }
-        if self.executedToolCallResults.length() > 0 {
-            return {value: self.executedToolCallResults.shift()};
+        // A reasoning-action cycle starts with an LLM call. Stop before making it if the
+        // iteration budget is already spent, so the limit bounds the number of LLM
+        // round-trips rather than the number of tool calls executed.
+        if self.remainingIterations <= 0 {
+            self.isCompleted = true;
+            self.maxIterationsExceeded = true;
+            return ();
         }
-        if self.pendingToolCalls.length() == 0 {
-            FunctionCall[]|string|Error llmResponse = self.reason();
-            if llmResponse is Error {
-                return {value: llmResponse};
-            }
-            if llmResponse is string {
-                return {value: self.act(llmResponse)};
-            }
-            if llmResponse.length() > 0 {
-                self.pendingToolCalls = llmResponse;
-            }
+        self.remainingIterations -= 1;
+        FunctionCall[]|string|Error llmResponse = self.reason();
+        if llmResponse is Error {
+            return {value: llmResponse};
         }
-        if self.agent.executeToolCallsInParallel && self.pendingToolCalls.length() > 1 {
-            FunctionCall[] toolCalls = self.pendingToolCalls;
-            self.pendingToolCalls = [];
-            return {value: self.act(toolCalls)};
-        }
-        FunctionCall nextToolCall = self.pendingToolCalls.shift();
-        return {value: self.act(nextToolCall)};
+        return {value: self.act(llmResponse)};
+    }
+
+    # Checks whether the execution stopped due to reaching the maximum number of
+    # reasoning-action cycles without producing a final answer.
+    #
+    # + return - True if the iteration limit was exceeded, false otherwise
+    public isolated function isMaxIterationsExceeded() returns boolean {
+        return self.maxIterationsExceeded;
     }
 }
 
@@ -368,7 +370,8 @@ isolated function executeToolCall(Agent agent, FunctionCall llmResponse, Context
 # + agent - Agent to be executed
 # + instruction - Instruction that the agent uses to execute the task
 # + query - Natural langauge commands to the agent  
-# + maxIter - No. of max iterations that agent will run to execute the task (default: 5)
+# + maxIter - Maximum number of reasoning-action cycles the agent will run to execute the task.
+# A single cycle is one LLM call plus the execution of every tool call it returns.
 # + context - Context values to be used by the agent to execute the task
 # + verbose - If true, then print the reasoning steps (default: true)
 # + sessionId - The ID associated with the memory
@@ -416,62 +419,23 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
     ChatUserMessage userMessage = {role: USER, content: query};
     history.push(userMessage);
 
-    Executor executor = new (agent, sessionId, progress = {instruction, query, context, executionId, history});
+    Executor executor = new (agent, sessionId, maxIter, progress = {instruction, query, context, executionId, history});
     ChatMessage[] temporaryMemory = [systemMessage, userMessage];
     ChatAssistantMessage? finalAssistantMessage = ();
-    int iter = 0;
-    foreach ExecutionResult|string|ExecutionError|Error step in executor {
-        ChatAssistantMessage|ChatFunctionMessage|Error iterationOutput = getOutputOfIteration(step);
-        ChatMessage[] iterationHistory = buildCurrentIterationHistory(executor.progress, history);
+    // Each value yielded by the executor is one complete reasoning-action cycle: the results
+    // of every tool call returned in a single LLM response, the final answer, or an error.
+    foreach (ExecutionResult|ExecutionError)[]|string|Error iterationResult in executor {
+        int iter = iterations.length() + 1;
         if verbose {
-            verbosePrint(step, iter);
+            io:println(string `${"\n\n"}Agent Iteration ${iter.toString()}`);
         }
-        if iter == maxIter {
-            log:printDebug("Maximum iterations reached without final answer",
-                    agentId = agentId,
-                    executionId = executionId,
-                    iterations = iter,
-                    stepsCompleted = steps.length(),
-                    sessionId = sessionId
-            );
-            break;
-        }
-        if step is ExecutionError && step.'error is UnauthorizedError {
-            error err = step.'error;
-            content = "I could not complete your request due to an authorization issue, " +
-            "possibly related to the access token or its permissions. Please check that your "
-            + "credentials are valid and have the required access, then try again";
-            Error newError = error Error(content.toString(), 'error = err);
-            iterationOutput = newError;
+        (ChatAssistantMessage|ChatFunctionMessage|Error)[] iterationOutputs = [];
+        boolean hasExecutionEnded = false;
+        if iterationResult is string {
+            content = iterationResult;
             if verbose {
-                verbosePrint(newError, iter);
+                verbosePrint(iterationResult);
             }
-            log:printDebug("Tool execution failed: ",
-                    err,
-                    executionId = executionId,
-                    iteration = iter,
-                    sessionId = sessionId
-            );
-            steps.push(step);
-            finalAssistantMessage = {role: ASSISTANT, content: content};
-            iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
-            break;
-        }
-        if step is Error {
-            error? cause = step.cause();
-            log:printDebug("Error occurred during agent iteration",
-                    step,
-                    executionId = executionId,
-                    iteration = iter,
-                    sessionId = sessionId,
-                    cause = cause !is () ? cause.toString() : "none"
-                );
-            steps.push(step);
-            iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
-            break;
-        }
-        if step is string {
-            content = step;
             log:printDebug("Final answer generated by agent",
                     agentId = agentId,
                     executionId = executionId,
@@ -479,22 +443,75 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
                     answer = content,
                     sessionId = sessionId
             );
-            finalAssistantMessage = {role: ASSISTANT, content: content};
-            iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
+            finalAssistantMessage = {role: ASSISTANT, content: iterationResult};
+            iterationOutputs.push({role: ASSISTANT, content: iterationResult});
+            hasExecutionEnded = true;
+        } else if iterationResult is Error {
+            error? cause = iterationResult.cause();
+            log:printDebug("Error occurred during agent iteration",
+                    iterationResult,
+                    executionId = executionId,
+                    iteration = iter,
+                    sessionId = sessionId,
+                    cause = cause !is () ? cause.toString() : "none"
+                );
+            steps.push(iterationResult);
+            iterationOutputs.push(iterationResult);
+            hasExecutionEnded = true;
+        } else {
+            foreach ExecutionResult|ExecutionError step in iterationResult {
+                if verbose {
+                    verbosePrint(step);
+                }
+                steps.push(step);
+                if step is ExecutionError && step.'error is UnauthorizedError {
+                    error err = step.'error;
+                    content = "I could not complete your request due to an authorization issue, " +
+                    "possibly related to the access token or its permissions. Please check that your "
+                    + "credentials are valid and have the required access, then try again";
+                    Error newError = error Error(content.toString(), 'error = err);
+                    if verbose {
+                        verbosePrint(newError);
+                    }
+                    log:printDebug("Tool execution failed: ",
+                            err,
+                            executionId = executionId,
+                            iteration = iter,
+                            sessionId = sessionId
+                    );
+                    finalAssistantMessage = {role: ASSISTANT, content: content};
+                    iterationOutputs.push(newError);
+                    hasExecutionEnded = true;
+                    break;
+                }
+                iterationOutputs.push(getOutputOfStep(step));
+                log:printDebug("Agent iteration step completed",
+                        agentId = agentId,
+                        executionId = executionId,
+                        iteration = iter,
+                        maxIterations = maxIter,
+                        stepsCompleted = steps.length(),
+                        sessionId = sessionId
+                );
+            }
+        }
+        time:Utc endTime = time:utcNow();
+        iterations.push({startTime, endTime, output: iterationOutputs,
+            history: buildCurrentIterationHistory(executor.progress, history)});
+        startTime = endTime;
+        if hasExecutionEnded {
             break;
         }
-        iter += 1;
-        log:printDebug("Agent iteration started",
+    }
+    boolean maxIterationsExceeded = executor.isMaxIterationsExceeded();
+    if maxIterationsExceeded {
+        log:printDebug("Maximum iterations reached without final answer",
                 agentId = agentId,
                 executionId = executionId,
-                iteration = iter,
-                maxIterations = maxIter,
+                iterations = iterations.length(),
                 stepsCompleted = steps.length(),
                 sessionId = sessionId
         );
-        steps.push(step);
-        iterations.push({startTime, endTime: time:utcNow(), history: iterationHistory, output: iterationOutput});
-        startTime = time:utcNow();
     }
 
     ChatMessage[]|Error intermediateFunctionCallMessages = createFunctionCallMessages(executor.progress);
@@ -520,11 +537,10 @@ isolated function run(Agent agent, string instruction, string query, int maxIter
         let var llmResponse = step.llmResponse
         where llmResponse is FunctionCall
         select llmResponse;
-    return {steps, iterations, answer: content, toolCalls};
+    return {steps, iterations, answer: content, toolCalls, maxIterationsExceeded};
 }
 
-isolated function verbosePrint(ExecutionResult|string|ExecutionError|Error step, int iter) {
-    io:println(string `${"\n\n"}Agent Iteration ${iter.toString()}`);
+isolated function verbosePrint(ExecutionResult|string|ExecutionError|Error step) {
     if step is string {
         io:println(string `${"\n\n"}Final Answer: ${step}${"\n\n"}`);
         return;
@@ -560,14 +576,7 @@ isolated function verbosePrint(ExecutionResult|string|ExecutionError|Error step,
     }
 }
 
-isolated function getOutputOfIteration(ExecutionResult|string|ExecutionError|Error step)
-    returns ChatAssistantMessage|ChatFunctionMessage|Error {
-    if step is Error {
-        return step;
-    }
-    if step is string {
-        return {role: ASSISTANT, content: step};
-    }
+isolated function getOutputOfStep(ExecutionResult|ExecutionError step) returns ChatFunctionMessage|Error {
     if step is ExecutionError {
         return step.'error;
     }

--- a/ballerina/agent.bal
+++ b/ballerina/agent.bal
@@ -76,7 +76,9 @@ public type AgentConfiguration record {|
     @display {label: "Tools"}
     (BaseToolKit|ToolConfig|FunctionTool)[] tools = [];
 
-    # The maximum number of iterations the agent performs to complete the task.
+    # The maximum number of reasoning-action cycles the agent performs to complete the task.
+    # A single cycle is one LLM call plus the execution of every tool call returned in
+    # that response, so multiple tool calls from one response count as one iteration.
     # Defaults to `max(number of tools, 10)` — i.e., at least 10, or more if the
     # agent has more tools available.
     @display {label: "Maximum Iterations"}
@@ -289,7 +291,7 @@ public isolated distinct class Agent {
         Iteration[] iterations = executionTrace.iterations;
         FunctionCall[]? toolCalls = executionTrace.toolCalls.length() == 0 ? () : executionTrace.toolCalls;
         do {
-            string answer = check getAnswer(executionTrace, self.maxIter);
+            string answer = check getAnswer(executionTrace);
             log:printDebug("Agent execution completed successfully",
                     executionId = executionId,
                     agentId = self.agentId,
@@ -336,13 +338,14 @@ public isolated distinct class Agent {
     }
 }
 
-isolated function getAnswer(ExecutionTrace executionTrace, int maxIter) returns string|Error {
+isolated function getAnswer(ExecutionTrace executionTrace) returns string|Error {
     string? answer = executionTrace.answer;
-    return answer ?: constructError(executionTrace.steps, maxIter);
+    return answer ?: constructError(executionTrace);
 }
 
-isolated function constructError((ExecutionResult|ExecutionError|Error)[] steps, int maxIter) returns Error {
-    if (steps.length() == maxIter) {
+isolated function constructError(ExecutionTrace executionTrace) returns Error {
+    (ExecutionResult|ExecutionError|Error)[] steps = executionTrace.steps;
+    if executionTrace.maxIterationsExceeded {
         return error MaxIterationExceededError("Maximum iteration limit exceeded while processing the query.",
             steps = steps);
     }

--- a/ballerina/agent.bal
+++ b/ballerina/agent.bal
@@ -91,10 +91,16 @@ public type AgentConfiguration record {|
     @display {label: "Memory"}
     Memory? memory?;
 
-    # Defines the strategies for loading tool schemas into an Agent. 
+    # Defines the strategies for loading tool schemas into an Agent.
     # By default, all tools are loaded without any filtering.
     @display {label: "Tool Loading Strategy"}
     ToolLoadingStrategy toolLoadingStrategy = NO_FILTER;
+
+    # Specifies whether multiple tool calls returned in a single LLM response are executed in parallel.
+    # If `true`, all tool calls from one LLM response are executed concurrently;
+    # otherwise, they are executed sequentially, one after another.
+    @display {label: "Allow Parallel Tool Call"}
+    boolean allowParallelToolCall = false;
 
     # Optional authentication details of the agent.
     @display {label: "Agent Credential"}
@@ -117,6 +123,8 @@ public isolated distinct class Agent {
     final cache:Cache tokenManager = new ();
     # Authentication configuration used for acquiring OAuth tokens when accessing secured tools.
     final readonly & Credential? agentCredential;
+    # Indicates whether multiple tool calls from a single LLM response are executed in parallel.
+    final boolean allowParallelToolCall;
     private final int maxIter;
     private final readonly & SystemPrompt systemPrompt;
     private final boolean verbose;
@@ -151,6 +159,7 @@ public isolated distinct class Agent {
             self.memory = memory ?: check new ShortTermMemory();
             self.stateless = memory is ();
             self.toolLoadingStrategy = config.toolLoadingStrategy;
+            self.allowParallelToolCall = config.allowParallelToolCall;
             self.agentCredential = agentCredential.cloneReadOnly();
             self.toolSchemas = self.toolStore.getToolSchema().cloneReadOnly();
             self.maxIter = maxIter is INFER_TOOL_COUNT ?
@@ -169,12 +178,12 @@ public isolated distinct class Agent {
         }
     }
 
-    # Use LLM to decide the next tool/step based on the function calling APIs.
+    # Use LLM to decide the next tool/step(s) based on the function calling APIs.
     #
     # + progress - Execution progress with the current query and execution history
     # + sessionId - The ID associated with the agent memory
     # + return - LLM response containing the tool or chat response (or an error if the call fails)
-    isolated function selectNextTool(ExecutionProgress progress, string sessionId = DEFAULT_SESSION_ID)
+    isolated function selectNextTools(ExecutionProgress progress, string sessionId = DEFAULT_SESSION_ID)
     returns FunctionCall[]|string|Error {
         ChatMessage[] messages = check createFunctionCallMessages(progress);
         messages.unshift(...progress.history);

--- a/ballerina/agent.bal
+++ b/ballerina/agent.bal
@@ -99,8 +99,8 @@ public type AgentConfiguration record {|
     # Specifies whether multiple tool calls returned in a single LLM response are executed in parallel.
     # If `true`, all tool calls from one LLM response are executed concurrently;
     # otherwise, they are executed sequentially, one after another.
-    @display {label: "Allow Parallel Tool Call"}
-    boolean allowParallelToolCall = false;
+    @display {label: "Execute Tool Calls in Parallel"}
+    boolean executeToolCallsInParallel = true;
 
     # Optional authentication details of the agent.
     @display {label: "Agent Credential"}
@@ -124,7 +124,7 @@ public isolated distinct class Agent {
     # Authentication configuration used for acquiring OAuth tokens when accessing secured tools.
     final readonly & Credential? agentCredential;
     # Indicates whether multiple tool calls from a single LLM response are executed in parallel.
-    final boolean allowParallelToolCall;
+    final boolean executeToolCallsInParallel;
     private final int maxIter;
     private final readonly & SystemPrompt systemPrompt;
     private final boolean verbose;
@@ -159,7 +159,7 @@ public isolated distinct class Agent {
             self.memory = memory ?: check new ShortTermMemory();
             self.stateless = memory is ();
             self.toolLoadingStrategy = config.toolLoadingStrategy;
-            self.allowParallelToolCall = config.allowParallelToolCall;
+            self.executeToolCallsInParallel = config.executeToolCallsInParallel;
             self.agentCredential = agentCredential.cloneReadOnly();
             self.toolSchemas = self.toolStore.getToolSchema().cloneReadOnly();
             self.maxIter = maxIter is INFER_TOOL_COUNT ?

--- a/ballerina/evaluation-trace.bal
+++ b/ballerina/evaluation-trace.bal
@@ -46,12 +46,13 @@ public type ToolSchema record {|
     map<json> parametersSchema?;
 |};
 
-# Represents a single execution step of an agent iteration.
+# Represents a single reasoning-action cycle of an agent execution.
 public type Iteration record {|
     # History of chat messages up to this iteration
     ChatMessage[] history;
-    # Output produced by the agent in this iteration
-    ChatAssistantMessage|ChatFunctionMessage|Error output;
+    # Outputs produced by the agent in this iteration. Contains one entry per tool call
+    # executed in the reasoning-action cycle, or a single assistant message or error
+    (ChatAssistantMessage|ChatFunctionMessage|Error)[] output;
     # Start time of the iteration
     time:Utc startTime;
     # End time of the iteration

--- a/ballerina/tests/agent-test.bal
+++ b/ballerina/tests/agent-test.bal
@@ -46,6 +46,36 @@ ToolConfig calculatorTool = {
     caller: calculatorToolMock
 };
 
+ToolConfig slowSearchTool = {
+    name: "Search",
+    description: " A search engine. Useful for when you need to answer questions about current events",
+    parameters: {
+        properties: {
+            params: {
+                properties: {
+                    query: {'type: "string", description: "The search query"}
+                }
+            }
+        }
+    },
+    caller: slowSearchToolMock
+};
+
+ToolConfig slowCalculatorTool = {
+    name: "Calculator",
+    description: "Useful for when you need to answer questions about math.",
+    parameters: {
+        properties: {
+            params: {
+                properties: {
+                    expression: {'type: "string", description: "The mathematical expression to evaluate"}
+                }
+            }
+        }
+    },
+    caller: slowCalculatorToolMock
+};
+
 ModelProvider model = new MockLLM();
 
 @test:Config {
@@ -193,4 +223,68 @@ function testAgentRunExecutesMultipleToolCallsFromSingleLlmResponseTogether() re
     // 2 tool calls required 3 LLM calls, one per tool call plus the final answer, because only
     // the first tool call in a response was ever acted on.
     test:assertEquals(scriptedModel.getChatCallCount(), 2);
+}
+
+@test:Config
+function testAgentRunExecutesToolCallsInParallel() returns error? {
+    MultiToolCallMockLLM scriptedModel = new;
+    Agent agent = check new ({
+        systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
+        model: scriptedModel,
+        tools: [slowSearchTool, slowCalculatorTool],
+        allowParallelToolCall: true
+    });
+
+    // The mock LLM returns both tool calls together, and each slow tool sleeps for 1 second
+    // while recording its execution time window.
+    Trace trace = check agent.run("Who is Leo DiCaprio's girlfriend, and what is 25 raised to the power of 0.43?");
+
+    // The answer and executed tool calls are identical to sequential execution.
+    ChatAssistantMessage|Error output = trace.output;
+    test:assertTrue(output is ChatAssistantMessage);
+    if output is ChatAssistantMessage {
+        test:assertEquals(output.content, "Leo DiCaprio's girlfriend is Camila Morrone, and 25 raised to the " +
+                "power of 0.43 is Answer: 3.991298452658078");
+    }
+    FunctionCall[]? toolCalls = trace.toolCalls;
+    test:assertTrue(toolCalls is FunctionCall[]);
+    if toolCalls is FunctionCall[] {
+        test:assertEquals(toolCalls.length(), 2);
+        test:assertEquals(toolCalls[0].name, "Search");
+        test:assertEquals(toolCalls[1].name, "Calculator");
+    }
+    test:assertEquals(trace.iterations.length(), 3);
+    test:assertEquals(scriptedModel.getChatCallCount(), 2);
+
+    // Both tool executions overlapped in time, proving they ran in parallel rather than
+    // one after the other.
+    [decimal, decimal] searchWindow = check getToolExecutionWindow("Search");
+    [decimal, decimal] calculatorWindow = check getToolExecutionWindow("Calculator");
+    test:assertTrue(searchWindow[0] < calculatorWindow[1] && calculatorWindow[0] < searchWindow[1],
+            string `Expected tool executions to overlap, but Search ran during ${searchWindow.toString()} ` +
+            string `and Calculator ran during ${calculatorWindow.toString()}`);
+}
+
+@test:Config
+function testAgentRunExecutesToolCallsSequentially() returns error? {
+    MultiToolCallMockLLM scriptedModel = new;
+    Agent agent = check new ({
+        systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
+        model: scriptedModel,
+        tools: [slowSearchTool, slowCalculatorTool]
+    });
+
+    string answer = check agent.run("Who is Leo DiCaprio's girlfriend, and what is 25 raised to the power of 0.43?");
+
+    test:assertEquals(answer, "Leo DiCaprio's girlfriend is Camila Morrone, and 25 raised to the " +
+            "power of 0.43 is Answer: 3.991298452658078");
+    test:assertEquals(scriptedModel.getChatCallCount(), 2);
+
+    // With `allowParallelToolCall` disabled (the default), the Search tool completes before
+    // the Calculator tool starts.
+    [decimal, decimal] searchWindow = check getToolExecutionWindow("Search");
+    [decimal, decimal] calculatorWindow = check getToolExecutionWindow("Calculator");
+    test:assertTrue(searchWindow[1] <= calculatorWindow[0],
+            string `Expected tool executions to run sequentially, but Search ran during ` +
+            string `${searchWindow.toString()} and Calculator ran during ${calculatorWindow.toString()}`);
 }

--- a/ballerina/tests/agent-test.bal
+++ b/ballerina/tests/agent-test.bal
@@ -232,7 +232,7 @@ function testAgentRunExecutesToolCallsInParallel() returns error? {
         systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
         model: scriptedModel,
         tools: [slowSearchTool, slowCalculatorTool],
-        allowParallelToolCall: true
+        executeToolCallsInParallel: true
     });
 
     // The mock LLM returns both tool calls together, and each slow tool sleeps for 1 second
@@ -271,7 +271,8 @@ function testAgentRunExecutesToolCallsSequentially() returns error? {
     Agent agent = check new ({
         systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
         model: scriptedModel,
-        tools: [slowSearchTool, slowCalculatorTool]
+        tools: [slowSearchTool, slowCalculatorTool],
+        executeToolCallsInParallel: false
     });
 
     string answer = check agent.run("Who is Leo DiCaprio's girlfriend, and what is 25 raised to the power of 0.43?");
@@ -280,7 +281,7 @@ function testAgentRunExecutesToolCallsSequentially() returns error? {
             "power of 0.43 is Answer: 3.991298452658078");
     test:assertEquals(scriptedModel.getChatCallCount(), 2);
 
-    // With `allowParallelToolCall` disabled (the default), the Search tool completes before
+    // With `executeToolCallsInParallel` disabled, the Search tool completes before
     // the Calculator tool starts.
     [decimal, decimal] searchWindow = check getToolExecutionWindow("Search");
     [decimal, decimal] calculatorWindow = check getToolExecutionWindow("Calculator");

--- a/ballerina/tests/agent-test.bal
+++ b/ballerina/tests/agent-test.bal
@@ -88,39 +88,33 @@ function testAgentExecutorRun() returns error? {
         tools: [searchTool, calculatorTool]
     });
     string query = "Who is Leo DiCaprio's girlfriend? What is her current age raised to the 0.43 power?";
-    Executor agentExecutor = new (agent, DEFAULT_SESSION_ID,
+    Executor agentExecutor = new (agent, DEFAULT_SESSION_ID, maxIter = 5,
         instruction = "Answer the questions", query = query, context = new, executionId = DEFAULT_EXECUTION_ID,
         history = []
     );
-    record {|ExecutionResult|string|ExecutionError|Error value;|}? result = agentExecutor.next();
-    if result is () {
-        test:assertFail("AgentExecutor.next returns an null during first iteration");
-    }
-    ExecutionResult|string|ExecutionError|Error output = result.value;
-    if output is Error {
-        test:assertFail("AgentExecutor.next returns an error during first iteration");
-    }
-    test:assertEquals(output, "Camila Morrone");
+    test:assertEquals(runNextIteration(agentExecutor), "Camila Morrone");
+    test:assertEquals(runNextIteration(agentExecutor), "25 years");
+    test:assertEquals(runNextIteration(agentExecutor), "Answer: 3.991298452658078");
+}
 
-    result = agentExecutor.next();
+// Runs the next reasoning-action cycle of the executor and returns the observation
+// of its single tool call.
+function runNextIteration(Executor agentExecutor) returns anydata {
+    record {|(ExecutionResult|ExecutionError)[]|string|Error value;|}? result = agentExecutor.next();
     if result is () {
-        test:assertFail("AgentExecutor.next returns an null during second iteration");
+        test:assertFail("AgentExecutor.next returned null before the execution completed");
     }
-    output = result.value;
-    if output is Error {
-        test:assertFail("AgentExecutor.next returns an error during second iteration");
+    (ExecutionResult|ExecutionError)[]|string|Error output = result.value;
+    if output !is (ExecutionResult|ExecutionError)[] {
+        test:assertFail(string `Expected tool execution results, but got ${output is Error ? output.message() : output}`);
     }
-    test:assertEquals(output, "25 years");
-
-    result = agentExecutor.next();
-    if result is () {
-        test:assertFail("AgentExecutor.next returns an null during third iteration");
+    test:assertEquals(output.length(), 1);
+    ExecutionResult|ExecutionError step = output[0];
+    if step !is ExecutionResult {
+        test:assertFail(string `Expected a successful tool execution, but got ${step.toString()}`);
     }
-    output = result.value;
-    if output is Error {
-        test:assertFail("AgentExecutor.next returns an error during third iteration");
-    }
-    test:assertEquals(output, "Answer: 3.991298452658078");
+    anydata|error observation = step.observation;
+    return observation is error ? observation.toString() : observation;
 }
 
 @test:Config
@@ -200,29 +194,72 @@ function testAgentRunExecutesMultipleToolCallsFromSingleLlmResponseTogether() re
         test:assertEquals(toolCalls[1].name, "Calculator");
     }
 
-    // Intermediate tool observations are present, one iteration per tool call, followed by the
-    // final answer iteration.
-    test:assertEquals(trace.iterations.length(), 3);
-    ChatAssistantMessage|ChatFunctionMessage|Error searchIterationOutput = trace.iterations[0].output;
-    test:assertTrue(searchIterationOutput is ChatFunctionMessage);
-    if searchIterationOutput is ChatFunctionMessage {
-        test:assertEquals(searchIterationOutput.name, "Search");
-        test:assertEquals(searchIterationOutput.content, "Camila Morrone");
+    // One iteration per reasoning-action cycle: the first holds both tool observations from
+    // the single LLM response, and the second holds the final answer.
+    test:assertEquals(trace.iterations.length(), 2);
+    (ChatAssistantMessage|ChatFunctionMessage|Error)[] toolCallIterationOutput = trace.iterations[0].output;
+    test:assertEquals(toolCallIterationOutput.length(), 2);
+    ChatAssistantMessage|ChatFunctionMessage|Error searchOutput = toolCallIterationOutput[0];
+    test:assertTrue(searchOutput is ChatFunctionMessage);
+    if searchOutput is ChatFunctionMessage {
+        test:assertEquals(searchOutput.name, "Search");
+        test:assertEquals(searchOutput.content, "Camila Morrone");
     }
-    ChatAssistantMessage|ChatFunctionMessage|Error calculatorIterationOutput = trace.iterations[1].output;
-    test:assertTrue(calculatorIterationOutput is ChatFunctionMessage);
-    if calculatorIterationOutput is ChatFunctionMessage {
-        test:assertEquals(calculatorIterationOutput.name, "Calculator");
-        test:assertEquals(calculatorIterationOutput.content, "Answer: 3.991298452658078");
+    ChatAssistantMessage|ChatFunctionMessage|Error calculatorOutput = toolCallIterationOutput[1];
+    test:assertTrue(calculatorOutput is ChatFunctionMessage);
+    if calculatorOutput is ChatFunctionMessage {
+        test:assertEquals(calculatorOutput.name, "Calculator");
+        test:assertEquals(calculatorOutput.content, "Answer: 3.991298452658078");
     }
-    ChatAssistantMessage|ChatFunctionMessage|Error finalIterationOutput = trace.iterations[2].output;
-    test:assertTrue(finalIterationOutput is ChatAssistantMessage);
+    (ChatAssistantMessage|ChatFunctionMessage|Error)[] finalIterationOutput = trace.iterations[1].output;
+    test:assertEquals(finalIterationOutput.length(), 1);
+    test:assertTrue(finalIterationOutput[0] is ChatAssistantMessage);
 
     // Only 2 LLM calls were made: one that returned both tool calls together, and one that
     // produced the final answer after both tool results were available. Previously, executing
     // 2 tool calls required 3 LLM calls, one per tool call plus the final answer, because only
     // the first tool call in a response was ever acted on.
     test:assertEquals(scriptedModel.getChatCallCount(), 2);
+}
+
+@test:Config
+function testMaxIterCountsReasoningActionCyclesNotToolCalls() returns error? {
+    MultiToolCallMockLLM scriptedModel = new;
+    Agent agent = check new ({
+        systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
+        model: scriptedModel,
+        tools: [searchTool, calculatorTool],
+        maxIter: 2
+    });
+
+    // Cycle 1: the LLM returns both tool calls in a single response. Cycle 2: the final answer.
+    // With `maxIter: 2` this must succeed because the two tool calls belong to a single
+    // reasoning-action cycle. Counting each tool call as its own iteration would exhaust
+    // the limit before the final answer and fail with `MaxIterationExceededError`.
+    string answer = check agent.run("Who is Leo DiCaprio's girlfriend, and what is 25 raised to the power of 0.43?");
+
+    test:assertEquals(answer, "Leo DiCaprio's girlfriend is Camila Morrone, and 25 raised to the " +
+            "power of 0.43 is Answer: 3.991298452658078");
+    test:assertEquals(scriptedModel.getChatCallCount(), 2);
+}
+
+@test:Config
+function testMaxIterationExceededErrorWhenAgentNeverProducesFinalAnswer() returns error? {
+    NeverAnsweringMockLLM scriptedModel = new;
+    Agent agent = check new ({
+        systemPrompt: {role: "Test Agent", instructions: "Answer the questions"},
+        model: scriptedModel,
+        tools: [searchTool, calculatorTool],
+        maxIter: 3
+    });
+
+    string|Error result = agent.run("Who is Leo DiCaprio's girlfriend?");
+
+    test:assertTrue(result is MaxIterationExceededError,
+            string `Expected MaxIterationExceededError, but got ${(typeof result).toString()}`);
+    // The limit is enforced before each reasoning call, so exactly `maxIter` LLM calls are
+    // made and no extra call is wasted once the budget is spent.
+    test:assertEquals(scriptedModel.getChatCallCount(), 3);
 }
 
 @test:Config
@@ -253,7 +290,7 @@ function testAgentRunExecutesToolCallsInParallel() returns error? {
         test:assertEquals(toolCalls[0].name, "Search");
         test:assertEquals(toolCalls[1].name, "Calculator");
     }
-    test:assertEquals(trace.iterations.length(), 3);
+    test:assertEquals(trace.iterations.length(), 2);
     test:assertEquals(scriptedModel.getChatCallCount(), 2);
 
     // Both tool executions overlapped in time, proving they ran in parallel rather than

--- a/ballerina/tests/mock-tools.bal
+++ b/ballerina/tests/mock-tools.bal
@@ -1,6 +1,8 @@
 import ballerina/io;
 import ballerina/jballerina.java;
 import ballerina/lang.regexp;
+import ballerina/lang.runtime;
+import ballerina/time;
 
 type SearchParams record {|
     string query;
@@ -37,6 +39,41 @@ isolated function calculatorToolMock(*CalculatorParams params) returns string {
     } else {
         return "Can't compute. Some information is missing";
     }
+}
+
+// Records the execution time window of each slow mock tool, keyed by tool name, so that tests
+// can assert whether tool executions overlapped (parallel) or not (sequential).
+isolated map<[decimal, decimal]> toolExecutionWindows = {};
+
+isolated function recordToolExecutionWindow(string toolName, decimal startTime, decimal endTime) {
+    lock {
+        toolExecutionWindows[toolName] = [startTime, endTime];
+    }
+}
+
+isolated function getToolExecutionWindow(string toolName) returns [decimal, decimal]|error {
+    lock {
+        if !toolExecutionWindows.hasKey(toolName) {
+            return error(string `Execution window not recorded for ${toolName} tool`);
+        }
+        return toolExecutionWindows.get(toolName).clone();
+    }
+}
+
+// Slow variants of the mock tools that sleep before responding and record their
+// execution time windows, used to verify parallel vs sequential tool execution.
+isolated function slowSearchToolMock(*SearchParams params) returns string {
+    decimal startTime = time:monotonicNow();
+    runtime:sleep(1);
+    recordToolExecutionWindow("Search", startTime, time:monotonicNow());
+    return "Camila Morrone";
+}
+
+isolated function slowCalculatorToolMock(*CalculatorParams params) returns string {
+    decimal startTime = time:monotonicNow();
+    runtime:sleep(1);
+    recordToolExecutionWindow("Calculator", startTime, time:monotonicNow());
+    return "Answer: 3.991298452658078";
 }
 
 isolated function sendMail(record {|string senderEmail; MessageRequest messageRequest;|} 'input) returns string|error {

--- a/ballerina/tests/mock-tools.bal
+++ b/ballerina/tests/mock-tools.bal
@@ -179,6 +179,41 @@ public isolated client class MultiToolCallMockLLM {
     }
 }
 
+// Always responds with a `Search` tool call and never produces a final answer, so an
+// execution can only terminate by exhausting the agent's iteration limit.
+// Used to verify `maxIter` enforcement.
+public isolated client class NeverAnsweringMockLLM {
+    *ModelProvider;
+    private int chatCallCount = 0;
+
+    isolated remote function chat(ChatMessage[]|ChatUserMessage messages, ChatCompletionFunctions[] tools = [],
+            string? stop = ()) returns ChatAssistantMessage|Error {
+        int callCount;
+        lock {
+            self.chatCallCount += 1;
+            callCount = self.chatCallCount;
+        }
+        return {
+            role: ASSISTANT,
+            toolCalls: [
+                {
+                    name: "Search",
+                    arguments: {params: {query: "Leo DiCaprio girlfriend"}},
+                    id: string `call-${callCount}`
+                }
+            ]
+        };
+    }
+
+    isolated remote function generate(Prompt prompt, typedesc<anydata> td = <>) returns td|Error = external;
+
+    public isolated function getChatCallCount() returns int {
+        lock {
+            return self.chatCallCount;
+        }
+    }
+}
+
 isolated function getChatAssistantMessageContent(int queryLevel) returns string|LlmError {
     match queryLevel {
         3 => {

--- a/ballerina/thread-reader.bal
+++ b/ballerina/thread-reader.bal
@@ -49,16 +49,12 @@ public isolated function loadConversationThreads(string evalSetPath) returns map
                     time:Utc iterationStartTime = check getUtcTime(rawIteration.startTime);
                     time:Utc iterationEndTime = check getUtcTime(rawIteration.endTime);
 
-                    ChatAssistantMessage|ChatFunctionMessage|string rawIterationOutput = rawIteration.output;
-                    readonly & (ChatAssistantMessage|ChatFunctionMessage|Error) iterationOutput =
-                        rawIterationOutput is string ? error(rawIterationOutput) : rawIterationOutput.cloneReadOnly();
-
                     readonly & ChatMessage[] messageHistory = rawIteration.history.'map(msg => getChatMessage(msg))
                         .cloneReadOnly();
                     readonly & Iteration agentIteration = {
                         startTime: iterationStartTime,
                         endTime: iterationEndTime,
-                        output: iterationOutput,
+                        output: getIterationOutputs(rawIteration.output),
                         history: messageHistory
                     };
                     agentIterations.push(agentIteration);
@@ -89,6 +85,13 @@ public isolated function loadConversationThreads(string evalSetPath) returns map
     } on fail error e {
         return error("failed to load conversation threads", e);
     }
+}
+
+isolated function getIterationOutputs(RawIterationOutput|RawIterationOutput[] rawOutput)
+        returns readonly & (ChatAssistantMessage|ChatFunctionMessage|Error)[] {
+    RawIterationOutput[] rawOutputs = rawOutput is RawIterationOutput[] ? rawOutput : [rawOutput];
+    return rawOutputs.'map(output => output is string ? error Error(output) : output.cloneReadOnly())
+        .cloneReadOnly();
 }
 
 isolated function getUtcTime(time:Utc|string timestamp) returns time:Utc|error {
@@ -132,9 +135,11 @@ type RawTrace record {|
     FunctionCall[] toolCalls?;
 |};
 
+type RawIterationOutput ChatAssistantMessage|ChatFunctionMessage|string;
+
 type RawIteration record {|
     TraceChatMessage[] history;
-    ChatAssistantMessage|ChatFunctionMessage|string output;
+    RawIterationOutput|RawIterationOutput[] output;
     string|time:Utc startTime;
     string|time:Utc endTime;
 |};

--- a/ballerina/tool.bal
+++ b/ballerina/tool.bal
@@ -129,13 +129,12 @@ public isolated class ToolStore {
             arguments = inputValues
         );
         isolated function caller = self.tools.get(name).caller;
-        ToolExecutionResult|error execution;
-        lock {
-            readonly & map<json> toolInput = self.isMcpTool(name)
-                ? {params: {name, arguments: inputValues}}.cloneReadOnly()
-                : inputValues.cloneReadOnly();
-            execution = trap executeTool(caller, toolInput, context);
-        }
+        // The tool is executed outside any `lock` statement so that multiple tool calls can
+        // run concurrently on the same tool store when parallel tool calling is enabled.
+        readonly & map<json> toolInput = self.isMcpTool(name)
+            ? {params: {name, arguments: inputValues}}.cloneReadOnly()
+            : inputValues.cloneReadOnly();
+        ToolExecutionResult|error execution = trap executeTool(caller, toolInput, context);
         if execution is error {
             log:printDebug("Tool execution failed",
                 execution,

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -48,6 +48,7 @@ type ExecutionTrace record {|
     string answer?;
     Iteration[] iterations;
     FunctionCall[] toolCalls;
+    boolean maxIterationsExceeded = false;
 |};
 
 # Configurations for controlling the behaviours when communicating with a remote HTTP endpoint.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,9 @@ This file documents all significant changes made to the Ballerina AI package acr
 
 ## [Unreleased]
 
+### Added
+- [Add Agent Configuration to Execute Tool Calls in Parallel](https://github.com/wso2/product-integrator/issues/1833)
+
 ### Fixed
 - [Fix `maxIter` Inference with Toolkits and Enforce Minimum of 10](https://github.com/wso2/product-integrator/issues/1112)
 - [Fix OpenAPI Spec Defaulting to Port 9090 When an AI Agent Listener Uses an Inline `http:Listener`](https://github.com/wso2/product-integrator/issues/1676)

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ This file documents all significant changes made to the Ballerina AI package acr
 ## [Unreleased]
 
 ### Added
-- [Add Agent Configuration to Execute Tool Calls in Parallel](https://github.com/wso2/product-integrator/issues/1833)
+- [Add Agent Configuration to Execute Tool Calls in Parallel](https://github.com/wso2/product-integrator/issues/1856)
 
 ### Fixed
 - [Fix `maxIter` Inference with Toolkits and Enforce Minimum of 10](https://github.com/wso2/product-integrator/issues/1112)


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/wso2/product-integrator/issues/1856

`executeToolCallsInParallel = false`
<img width="3022" height="1556" alt="image" src="https://github.com/user-attachments/assets/81e465e1-2e09-40e3-a60d-9452b7f0c01a" />

`executeToolCallsInParallel = true`
<img width="3022" height="1556" alt="image" src="https://github.com/user-attachments/assets/7d89f40c-a0c8-4a78-b916-9b98af39cbdb" />

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [x] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added agent support for running multiple tool calls from a single assistant response in parallel by default, with a new `executeToolCallsInParallel` configuration option to override the behavior.

Refactored agent execution to treat each reasoning/action cycle as one iteration, updated execution trace and conversation-thread output handling to record multiple tool results per cycle, and adjusted answer/error handling to use the new trace state.

Also updated tool execution to allow concurrent calls, added coverage for parallel vs. sequential execution and iteration limits, introduced slow mock tools and a never-answering mock LLM for testing, and refreshed the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->