### PR TITLE
Fix Trivy scan findings for jackson-databind, opentelemetry-api, and jline

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,2 +1,20 @@
 CVE-2025-48924
 CVE-2021-0341
+
+# io.opentelemetry:opentelemetry-api 1.32.0 (opentelemetry-api-1.32.0.jar)
+# Transitive dependency of the Ballerina platform itself, not of this package:
+# ai-native -> org.ballerinalang:ballerina-lang:2201.12.0 -> ballerina-runtime -> opentelemetry-api:1.32.0.
+# It is not declared in Ballerina.toml and is not packed into the bala; at runtime it is
+# provided by the Ballerina distribution. The fix (1.62.0) must come from a
+# ballerina-lang/distribution upgrade and cannot be applied in this repository.
+CVE-2026-45292
+
+# org.jline:jline-remote-telnet, bundled inside the jline 3.25.0 uber-jar (jline-3.25.0.jar)
+# Transitive dependency of the Ballerina compiler toolchain, not of this package:
+# ai-native -> ballerina-lang -> central-client -> me.tongfei:progressbar -> org.jline:jline
+# (pinned to 3.25.0 by the ballerina-lang platform). Not declared in Ballerina.toml and not
+# packed into the bala. The vulnerable component is JLine's embedded telnet server, which is
+# never started by this package or the Ballerina runtime. Fixed only by a ballerina-lang
+# upgrade to jline 4.x.
+GHSA-2r2c-cx56-8933
+GHSA-47qp-hqvx-6r3f

--- a/.trivyignore
+++ b/.trivyignore
@@ -7,7 +7,8 @@ CVE-2021-0341
 # It is not declared in Ballerina.toml and is not packed into the bala; at runtime it is
 # provided by the Ballerina distribution. The fix (1.62.0) must come from a
 # ballerina-lang/distribution upgrade and cannot be applied in this repository.
-CVE-2026-45292
+# Expiry forces re-evaluation against the then-current distribution.
+CVE-2026-45292 exp:2027-01-15
 
 # org.jline:jline-remote-telnet, bundled inside the jline 3.25.0 uber-jar (jline-3.25.0.jar)
 # Transitive dependency of the Ballerina compiler toolchain, not of this package:
@@ -15,6 +16,6 @@ CVE-2026-45292
 # (pinned to 3.25.0 by the ballerina-lang platform). Not declared in Ballerina.toml and not
 # packed into the bala. The vulnerable component is JLine's embedded telnet server, which is
 # never started by this package or the Ballerina runtime. Fixed only by a ballerina-lang
-# upgrade to jline 4.x.
-GHSA-2r2c-cx56-8933
-GHSA-47qp-hqvx-6r3f
+# upgrade to jline 4.x. Expiry forces re-evaluation against the then-current distribution.
+GHSA-2r2c-cx56-8933 exp:2027-01-15
+GHSA-47qp-hqvx-6r3f exp:2027-01-15

--- a/ballerina-tests/Dependencies.toml
+++ b/ballerina-tests/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.0"
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.11.2"
+version = "1.12.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -41,6 +41,9 @@ ballerina {
 configurations {
     externalJars {
         exclude group: 'org.ballerinalang', module: 'maven-resolver'
+        // Unused at runtime: the langchain4j document-splitting APIs used by ai-native never
+        // reach Jackson, and the bala does not pack it (CVE-2026-54512/54513/54514/54515)
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,9 +20,9 @@ langchain4jVersion=1.1.0
 
 # Ballerina Library Dependencies
 # Level 01
-stdlibIoVersion=1.8.0
+stdlibIoVersion=1.8.1
 stdlibTimeVersion=2.7.0
-stdlibUrlVersion=2.6.1
+stdlibUrlVersion=2.6.2
 stdlibMathVectorVersion=1.2.0
 stdlibRandomVersion=1.7.0
 
@@ -36,9 +36,9 @@ stdlibTaskVersion=2.10.0
 # Level 03
 stdlibCacheVersion=3.10.0
 stdlibFileVersion=1.12.0
-stdlibMimeVersion=2.12.1
+stdlibMimeVersion=2.12.2
 stdlibUuidVersion=1.10.0
-stdlibDataXmldataVersion=1.6.2
+stdlibDataXmldataVersion=1.6.3
 
 # Level 04
 stdlibAuthVersion=2.14.0
@@ -48,7 +48,7 @@ stdlibOAuth2Version=2.14.1
 stdlibYamlVersion=0.8.0
 
 # Level 05
-stdlibHttpVersion=2.14.9
+stdlibHttpVersion=2.14.11
 
 stdlibMcpVersion=1.0.3
 


### PR DESCRIPTION
## Purpose
$subject

Resolve the vulnerabilities reported by the Trivy [scan](https://github.com/ballerina-platform/module-ballerina-ai/actions/runs/29366981053/job/87200895348):

| Library | Vulnerabilities | Resolution |
|---|---|---|
| `jackson-databind-2.19.0.jar` | CVE-2026-54512, CVE-2026-54513 (HIGH), CVE-2026-54514, CVE-2026-54515 (MEDIUM) | Excluded from the build — jar removed |
| `opentelemetry-api-1.32.0.jar` | CVE-2026-45292 (MEDIUM) | Suppressed in `.trivyignore` |
| `jline-3.25.0.jar` (`jline-remote-telnet`) | GHSA-2r2c-cx56-8933, GHSA-47qp-hqvx-6r3f (HIGH) | Suppressed in `.trivyignore` |

### jackson-databind — excluded from `externalJars`

`jackson-databind` enters the build only as a transitive of `dev.langchain4j:langchain4j-core:1.1.0`
(via `externalJars project(":ai-native")`) and lands in `ballerina/lib/`, which is what Trivy scans.
It is not declared in `Ballerina.toml` and is **not packed into the bala**.

Verified it is safe to drop entirely: `ai-native` only uses langchain4j's document-splitting APIs
(`Document`, `Metadata`, `TextSegment`, `DocumentBy*Splitter`), and a `jdeps` class-level
reachability analysis over both langchain4j jars shows no path from those classes to any
`com.fasterxml.*` class. Jackson usage in langchain4j 1.1.0 is confined to features we don't use
(chat-message JSON codecs, `@StructuredPrompt`, JSON-schema generation, `InMemoryEmbeddingStore`
persistence).

> **Note:** if we later adopt any of those langchain4j features, Jackson becomes a real runtime
> dependency and must be added to `Ballerina.toml` at a patched version (≥ 2.21.5).

### opentelemetry-api / jline — suppressed

Both belong to the Ballerina platform, not to this package (verified with
`./gradlew :ai-ballerina:dependencyInsight`):

- `opentelemetry-api` ← `ballerina-lang → ballerina-runtime`. At application runtime it is bundled
  inside `ballerina-rt`, so the fix (1.62.0) must come from a distribution upgrade.
- `jline` ← `ballerina-lang → central-client → progressbar`. It exists only on the `bal` CLI's
  tooling classpath (`bre/lib`) and is never on an application's classpath; the flagged embedded
  telnet server is never started. Fixed only by a ballerina-lang upgrade to jline 4.x.

Neither is declared in `Ballerina.toml` nor packed into the bala; they appear in `ballerina/lib/`
only because `ai-native`'s ballerina-lang transitives leak into `externalJars`. The suppressions
should be revisited when moving past distribution 2201.12.0.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Removed an unused Jackson dependency from the Ballerina build configuration to streamline the packaged artifacts.
- Updated the dependency handling and suppression configuration for Trivy so that known third-party components bundled with the Ballerina distribution are not flagged pending an upstream/distribution upgrade.
- Added review deadlines and clearer documentation in the Trivy ignore configuration to ensure these suppressions are revisited after upgrading beyond distribution 2201.12.0.
- Bumped the `ballerina/ai` test package version and refreshed several Ballerina standard library dependency version properties to align with the updated native/library setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->